### PR TITLE
feat: AsyncResult returning intermediate_results

### DIFF
--- a/lib/ruby_reactor.rb
+++ b/lib/ruby_reactor.rb
@@ -65,10 +65,11 @@ module RubyReactor
 
   # Async result for background job execution
   class AsyncResult
-    attr_reader :job_id
+    attr_reader :job_id, :intermediate_results
 
-    def initialize(job_id:)
+    def initialize(job_id:, intermediate_results: {})
       @job_id = job_id
+      @intermediate_results = intermediate_results
     end
 
     def async?

--- a/lib/ruby_reactor/async_router.rb
+++ b/lib/ruby_reactor/async_router.rb
@@ -2,14 +2,14 @@
 
 module RubyReactor
   class AsyncRouter
-    def self.perform_async(serialized_context, reactor_class_name = nil)
+    def self.perform_async(serialized_context, reactor_class_name = nil, intermediate_results: {})
       job_id = SidekiqWorkers::Worker.perform_async(serialized_context, reactor_class_name)
-      RubyReactor::AsyncResult.new(job_id: job_id)
+      RubyReactor::AsyncResult.new(job_id: job_id, intermediate_results: intermediate_results)
     end
 
-    def self.perform_in(delay, serialized_context, reactor_class_name = nil)
+    def self.perform_in(delay, serialized_context, reactor_class_name = nil, intermediate_results: {})
       job_id = SidekiqWorkers::Worker.perform_in(delay, serialized_context, reactor_class_name)
-      RubyReactor::AsyncResult.new(job_id: job_id)
+      RubyReactor::AsyncResult.new(job_id: job_id, intermediate_results: intermediate_results)
     end
 
     # rubocop:disable Metrics/ParameterLists

--- a/lib/ruby_reactor/executor/step_executor.rb
+++ b/lib/ruby_reactor/executor/step_executor.rb
@@ -177,7 +177,11 @@ module RubyReactor
 
         serialized_context = ContextSerializer.serialize(context_to_serialize)
 
-        result = configuration.async_router.perform_async(serialized_context, reactor_class_name)
+        result = configuration.async_router.perform_async(
+          serialized_context,
+          reactor_class_name,
+          intermediate_results: @context.intermediate_results
+        )
 
         # Handle different result types from async router
         case result

--- a/lib/ruby_reactor/step/map_step.rb
+++ b/lib/ruby_reactor/step/map_step.rb
@@ -151,7 +151,7 @@ module RubyReactor
                                          reactor_class_info: reactor_class_info, step_name: step_name)
                    end
 
-          RubyReactor::AsyncResult.new(job_id: job_id)
+          RubyReactor::AsyncResult.new(job_id: job_id, intermediate_results: context.intermediate_results)
         end
 
         def prepare_async_execution(context, map_id, count)

--- a/spec/ruby_reactor_spec.rb
+++ b/spec/ruby_reactor_spec.rb
@@ -796,4 +796,40 @@ RSpec.describe RubyReactor do
       expect(result.value).to eq(20) # 5 * 3 = 15 after retry, then + 5 in after_compose
     end
   end
+
+  describe "AsyncResult returns job_id and intermediate_results" do
+    let(:reactor_class) do
+      Class.new(RubyReactor::Reactor) do
+        input :value
+
+        step :sync_step do
+          run do |args, _context|
+            Success(args[:value] + 1)
+          end
+        end
+        step :async_step do
+          async true
+          argument :value, result(:sync_step)
+          run do |args, _context|
+            Success(args[:value] * 2)
+          end
+        end
+      end
+    end
+
+    before do
+      allow(RubyReactor::Configuration.instance).to receive(:async_router).and_return(RubyReactor::AsyncRouter)
+    end
+
+    it "returns job_id and intermediate_results correctly" do
+      reactor = reactor_class.new
+      async_result = reactor.run(value: 10)
+
+      expect(async_result).to be_a(RubyReactor::AsyncResult)
+      expect(async_result.job_id).not_to be_nil
+      expect(async_result.intermediate_results).to be_a(Hash)
+      expect(async_result.intermediate_results).to have_key(:sync_step)
+      expect(async_result.intermediate_results[:sync_step]).to eq(11) # 10 + 1
+    end
+  end
 end

--- a/spec/support/worker_mock.rb
+++ b/spec/support/worker_mock.rb
@@ -2,7 +2,7 @@
 
 module Support
   class WorkerMock
-    def self.perform_async(serialized_context, reactor_class_name = nil)
+    def self.perform_async(serialized_context, reactor_class_name = nil, intermediate_results: {})
       warn "[WORKER_MOCK] perform_async CALLED"
       # Execute inline by calling Worker.perform which returns an Executor or Failure
       warn "[WORKER_MOCK] About to call perform"
@@ -31,9 +31,9 @@ module Support
       raise
     end
 
-    def self.perform_in(_delay, serialized_context, reactor_class_name = nil)
+    def self.perform_in(_delay, serialized_context, reactor_class_name = nil, intermediate_results: {})
       # Mock implementation of perform_in - same as perform_async for testing
-      perform_async(serialized_context, reactor_class_name)
+      perform_async(serialized_context, reactor_class_name, intermediate_results: intermediate_results)
     end
 
     def self.perform(serialized_context, reactor_class_name = nil)


### PR DESCRIPTION
This pull request enhances the async execution flow in the `RubyReactor` framework by enabling the propagation and access of `intermediate_results` throughout async job handling. This allows async steps and their results to be tracked and passed between components, improving transparency and debugging. The changes include updates to both core logic and test mocks, as well as new test coverage.

### Async execution improvements

* The `RubyReactor::AsyncResult` class now accepts and exposes an `intermediate_results` hash, allowing async job results to include step-level outputs.
* The `RubyReactor::AsyncRouter` methods `perform_async` and `perform_in` now accept and forward `intermediate_results`, ensuring these are included in the resulting `AsyncResult`.
* The `handle_async_step` method in `StepExecutor` passes the current context's `intermediate_results` to the async router, so downstream async jobs have access to prior step results.
* The `run_async` method in `MapStep` ensures that created `AsyncResult` objects include the current context's `intermediate_results`.

### Testing and mocks

* The `WorkerMock` class in test support now accepts and propagates `intermediate_results` in its async methods, maintaining test parity with production logic. [[1]](diffhunk://#diff-b74174461fbef498d718f4650bf65568a469cfafddd3515a85de1d53ad23d781L5-R5) [[2]](diffhunk://#diff-b74174461fbef498d718f4650bf65568a469cfafddd3515a85de1d53ad23d781L34-R36)
* Added a new spec to verify that `AsyncResult` correctly returns both `job_id` and `intermediate_results`, ensuring the feature works as intended.