### PR TITLE
feat: Introduce reactor interrupt functionality, allowing pausing and…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 # rspec failure tracking
 .rspec_status
 log
+ui

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,13 +27,13 @@ Metrics/BlockLength:
 Metrics/MethodLength:
   Exclude:
     - spec/**/*
-  Max: 25
+  Max: 36
   CountComments: false
 
 Metrics/ClassLength:
   Exclude:
     - spec/**/*
-  Max: 200
+  Max: 250
 
 Style/Documentation:
   Exclude:
@@ -96,3 +96,10 @@ RSpec/DescribeClass:
 
 RSpec/AnyInstance:
   Enabled: false
+
+Naming/VariableNumber:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Max: 200
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A dynamic, dependency-resolving saga orchestrator for Ruby. Ruby Reactor impleme
 - **Map & Parallel Execution**: Iterate over collections in parallel with the `map` step, distributing work across multiple workers.
 - **Retries**: Configurable retry logic for failed steps, with exponential backoff.
 - **Compensation**: Automatic rollback of completed steps when a failure occurs.
+- **Interrupts**: Pause and resume workflows to wait for external events (webhooks, user approvals).
 - **Input Validation**: Integrated with `dry-validation` for robust input checking.
 
 ## Installation
@@ -196,6 +197,42 @@ def create(params)
    
    # do something with user
 end
+```
+
+### Interrupts (Pause & Resume)
+
+Pause execution to wait for external events like webhooks or user approvals.
+
+```ruby
+class ApprovalReactor < RubyReactor::Reactor
+  step :submit_request do
+    run { |args| RequestService.submit(args) }
+  end
+
+  interrupt :wait_for_manager do
+    wait_for :submit_request
+    # Resume using this ID
+    correlation_id { |ctx| "req-#{ctx.result(:submit_request)[:id]}" }
+  end
+
+  step :process_decision do
+    argument :decision, result(:wait_for_manager)
+    run do |args| 
+      args[:decision] == 'approved' ? Success() : Failure("Rejected")
+    end
+  end
+end
+
+# Usage:
+# 1. Start execution
+execution = ApprovalReactor.run(params) # => Returns Paused status
+
+# 2. Later, resume it via correlation ID
+ApprovalReactor.continue_by_correlation_id(
+  correlation_id: "req-123",
+  payload: "approved",
+  step_name: :wait_for_manager
+)
 ```
 
 ### Map & Parallel Execution
@@ -539,6 +576,9 @@ Master the `map` feature for processing collections. Learn about parallel execut
 
 ### [Retry Configuration](documentation/retry_configuration.md)
 Configure robust retry policies for your steps. This guide details the available backoff strategies (exponential, linear, fixed), how to configure retries at the reactor or step level, and how async retries work without blocking workers.
+
+### [Interrupts](documentation/interrupts.md)
+Learn how to pause and resume reactors to handle long-running processes, manual approvals, and asynchronous callbacks. Patterns for correlation IDs, timeouts, and payload validation.
 
 ### Examples
 - [Order Processing](documentation/examples/order_processing.md) - Complete order processing workflow example

--- a/README.md
+++ b/README.md
@@ -588,12 +588,19 @@ Learn how to pause and resume reactors to handle long-running processes, manual 
 ## Future improvements
 
 - [X] Global id to serialize ActiveRecord classes
-- [ ] Middlewares
-- [ ] Descriptive errors
+- [X] Descriptive errors
 - [X] `map` step to iterate over arrays in parallel
 - [X] `compose` special step to execute reactors as step
+- [X] `interrupt` to pause and resume reactors
+- [ ] Middlewares
 - [ ] Async ruby to parallelize same level steps
 - [ ] Dedicated interface to inspect reactor results and errors
+- [ ] Multiple storage adapters
+  - [X] Redis
+  - [ ] ActiveRecord
+- [ ] Multiple Async adapters
+  - [X] Sidekiq
+  - [ ] ActiveJob
 
 ## Development
 

--- a/documentation/interrupts.md
+++ b/documentation/interrupts.md
@@ -119,7 +119,8 @@ You can cancel a paused reactor if the operation is no longer needed.
 # Undo: Runs defined compensations for completed steps in reverse order, then deletes execution.
 ReportReactor.undo("uuid-123")
 
-# Cancel: Stops execution immediately and deletes stored state without running compensations.
+# Cancel: Stops execution immediately and marks the reactor as cancelled with the provided reason.
+# The context is preserved for inspection, but resumption is disabled.
 ReportReactor.cancel("uuid-123", reason: "User cancelled")
 ```
 

--- a/documentation/interrupts.md
+++ b/documentation/interrupts.md
@@ -1,0 +1,154 @@
+# Interrupts (Pause & Resume)
+
+RubyReactor introduces the `interrupt` mechanism to support long-running processes that require external input, such as user approvals, webhooks, or asynchronous job completions. Unlike standard steps that execute immediately, an `interrupt` pauses the reactor execution and persists its state, waiting for a signal to resume.
+
+## DSL Usage
+
+Use the `interrupt` keyword to define a pause point in your reactor.
+
+```ruby
+class ReportReactor < RubyReactor::Reactor
+  step :request_report do
+    run do
+      response = HTTP.post("https://api.example.com/reports")
+      Success(response.fetch(:id))
+    end
+  end
+
+  interrupt :wait_for_report do
+    # Declare dependency: execution must trigger this interrupt only after :request_report succeeds
+    wait_for :request_report
+
+    # Optional: deterministic correlation ID for looking up this execution later
+    correlation_id do |context|
+      "report-#{context.result(:request_report)}"
+    end
+
+    # Optional: timeout in seconds
+    # Strategies:
+    # - :lazy (default) - checked only when resume is attempted
+    # - :active - schedules a background job to wake up the reactor and fail it
+    timeout 1800, strategy: :active
+
+    # Optional: validate incoming payload immediately using dry-validation
+    validate do
+      required(:status).filled(:string)
+      required(:url).filled(:string)
+    end
+  end
+
+  step :process_report do
+    # The result of the interrupt step is the payload provided when resuming
+    argument :webhook_payload, result(:wait_for_report)
+
+    run do |args|
+      Success(ReportProcessor.call(args[:webhook_payload]))
+    end
+  end
+end
+```
+
+### Options
+
+*   **`wait_for`**: declare dependencies similar to `step`.
+*   **`correlation_id`**: A block that returns a unique string to identify this execution. This allows you to resume the reactor using a business key (e.g., order ID) instead of the internal execution UUID.
+*   **`timeout`**: Set a time limit for the interrupt.
+*   **`validate`**: A `dry-validation` schema block to validate the payload provided when resuming.
+
+## Runtime Behavior
+
+When a reactor encounters an `interrupt`:
+
+1.  It executes any dependencies.
+2.  It persists the full `Context` (results of previous steps) to the configured storage (e.g., Redis).
+3.  It returns an `InterruptResult` and halts execution.
+
+```ruby
+execution = ReportReactor.run(company_id: 1)
+
+if execution.paused?
+  execution.id         # => "uuid-123"
+  execution.status     # => :paused
+end
+```
+
+## Resuming Execution
+
+You can resume a paused reactor using its UUID or the defined `correlation_id`.
+
+### By UUID
+
+```ruby
+ReportReactor.continue(
+  id: "uuid-123",
+  payload: { status: "completed", url: "..." },
+  step_name: :wait_for_report
+)
+```
+
+### By Correlation ID
+
+```ruby
+ReportReactor.continue_by_correlation_id(
+  correlation_id: "report-999",
+  payload: { status: "completed", url: "..." },
+  step_name: :wait_for_report
+)
+```
+
+### Resuming Method Styles
+
+There are two ways to invoke continuation:
+
+1.  **Strict / Fire-and-Forget (Class Method)**:
+    *   `Reactor.continue(...)`
+    *   If payload is invalid, it **automatically compensates (undo)** and cancels the reactor.
+    *   Best for webhooks where you can't ask the sender to fix the payload.
+
+2.  **Flexible (Instance Method)**:
+    *   First find the reactor: `reactor = ReportReactor.find("uuid-123")`
+    *   Then call: `result = reactor.continue(payload: ..., step_name: :wait_for_report)`
+    *   If payload is invalid, it returns a failure result but **does not** cancel execution.
+    *   Allows you to handle the error (e.g., show a form error to a user) and try again.
+
+## Cancellation & Undo
+
+You can cancel a paused reactor if the operation is no longer needed.
+
+```ruby
+# Undo: Runs defined compensations for completed steps in reverse order, then deletes execution.
+ReportReactor.undo("uuid-123")
+
+# Cancel: Stops execution immediately and deletes stored state without running compensations.
+ReportReactor.cancel("uuid-123", reason: "User cancelled")
+```
+
+## Common Use Cases
+
+### Human Approvals
+
+```ruby
+interrupt :wait_for_approval do
+  wait_for :submit_request
+  correlation_id { |ctx| "approval-#{ctx.input(:request_id)}" }
+end
+
+step :process_decision do
+  argument :decision, result(:wait_for_approval)
+  run do |args|
+    if args[:decision][:approved]
+      Success("Approved")
+    else
+      Failure("Rejected")
+    end
+  end
+end
+```
+
+### Webhooks
+
+Use `correlation_id` to map an external resource ID (like a Payment Intent ID) back to the reactor waiting for confirmation.
+
+### Scheduled Follow-ups
+
+Using `timeout` with `strategy: :active` to wake up a reactor after a delay if no external event occurs (e.g., expiring a reservation).

--- a/lib/ruby_reactor.rb
+++ b/lib/ruby_reactor.rb
@@ -120,11 +120,12 @@ module RubyReactor
 
   # Async result for background job execution
   class AsyncResult
-    attr_reader :job_id, :intermediate_results
+    attr_reader :job_id, :intermediate_results, :execution_id
 
-    def initialize(job_id:, intermediate_results: {})
+    def initialize(job_id:, intermediate_results: {}, execution_id: nil)
       @job_id = job_id
       @intermediate_results = intermediate_results
+      @execution_id = execution_id
     end
 
     def async?

--- a/lib/ruby_reactor/async_router.rb
+++ b/lib/ruby_reactor/async_router.rb
@@ -4,12 +4,16 @@ module RubyReactor
   class AsyncRouter
     def self.perform_async(serialized_context, reactor_class_name = nil, intermediate_results: {})
       job_id = SidekiqWorkers::Worker.perform_async(serialized_context, reactor_class_name)
-      RubyReactor::AsyncResult.new(job_id: job_id, intermediate_results: intermediate_results)
+      context = ContextSerializer.deserialize(serialized_context)
+      RubyReactor::AsyncResult.new(job_id: job_id, intermediate_results: intermediate_results,
+                                   execution_id: context.context_id)
     end
 
     def self.perform_in(delay, serialized_context, reactor_class_name = nil, intermediate_results: {})
       job_id = SidekiqWorkers::Worker.perform_in(delay, serialized_context, reactor_class_name)
-      RubyReactor::AsyncResult.new(job_id: job_id, intermediate_results: intermediate_results)
+      context = ContextSerializer.deserialize(serialized_context)
+      RubyReactor::AsyncResult.new(job_id: job_id, intermediate_results: intermediate_results,
+                                   execution_id: context.context_id)
     end
 
     # rubocop:disable Metrics/ParameterLists

--- a/lib/ruby_reactor/context.rb
+++ b/lib/ruby_reactor/context.rb
@@ -4,7 +4,8 @@ module RubyReactor
   class Context
     attr_accessor :inputs, :intermediate_results, :private_data, :current_step, :retry_count, :concurrency_key,
                   :retry_context, :reactor_class, :execution_trace, :inline_async_execution, :undo_stack, :test_mode,
-                  :parent_context, :root_context, :composed_contexts, :context_id, :map_operations, :map_metadata
+                  :parent_context, :root_context, :composed_contexts, :context_id, :map_operations, :map_metadata,
+                  :cancelled, :cancellation_reason
 
     def initialize(inputs = {}, reactor_class = nil)
       @context_id = SecureRandom.uuid
@@ -23,6 +24,8 @@ module RubyReactor
       @inline_async_execution = false # Flag to prevent nested async calls
       @undo_stack = [] # Initialize the undo stack
       @test_mode = false
+      @cancelled = false
+      @cancellation_reason = nil
       @parent_context = nil
       @root_context = nil
     end
@@ -97,7 +100,9 @@ module RubyReactor
         retry_context: @retry_context.serialize_for_retry,
         execution_trace: ContextSerializer.serialize_value(@execution_trace),
         undo_stack: serialize_undo_stack,
-        test_mode: @test_mode
+        test_mode: @test_mode,
+        cancelled: @cancelled,
+        cancellation_reason: @cancellation_reason
       }
     end
 
@@ -118,11 +123,8 @@ module RubyReactor
       context.execution_trace = ContextSerializer.deserialize_value(data["execution_trace"]) || []
       context.undo_stack = deserialize_undo_stack(data["undo_stack"] || [], context.reactor_class)
       context.test_mode = data["test_mode"] || false
-
-      # Reconstruct parent/root relationships if nested contexts exist in private_data
-      # This is tricky because private_data is just a hash.
-      # We rely on the fact that nested contexts are stored in private_data by ComposeStep
-      # But here we just deserialize the values.
+      context.cancelled = data["cancelled"] || false
+      context.cancellation_reason = data["cancellation_reason"]
 
       context
     end

--- a/lib/ruby_reactor/context.rb
+++ b/lib/ruby_reactor/context.rb
@@ -37,6 +37,7 @@ module RubyReactor
         value
       end
     end
+    alias input get_input
 
     def get_result(step_name, path = nil)
       value = @intermediate_results[step_name.to_sym] || @intermediate_results[step_name.to_s]
@@ -48,6 +49,7 @@ module RubyReactor
         value
       end
     end
+    alias result get_result
 
     def set_result(step_name, value)
       @intermediate_results[step_name.to_sym] = value

--- a/lib/ruby_reactor/dsl/interrupt_builder.rb
+++ b/lib/ruby_reactor/dsl/interrupt_builder.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module RubyReactor
+  module Dsl
+    class InterruptBuilder < StepBuilder
+      def initialize(name, reactor = nil)
+        super(name, nil, reactor)
+        @correlation_id_block = nil
+        @timeout_config = nil
+        @validation_schema = nil
+      end
+
+      def correlation_id(&block)
+        @correlation_id_block = block
+      end
+
+      def timeout(seconds, strategy: :lazy)
+        @timeout_config = { duration: seconds, strategy: strategy }
+      end
+
+      def validate(&block)
+        check_dry_validation_available!
+        @validation_schema = build_validation_schema(&block)
+      end
+
+      def build
+        step_config = {
+          name: @name,
+          correlation_id_block: @correlation_id_block,
+          timeout_config: @timeout_config,
+          validation_schema: @validation_schema,
+          dependencies: @dependencies,
+          async: false, # Interrupts are effectively boundaries, not async jobs themselves (until resumed)
+          conditions: @conditions,
+          guards: @guards
+        }
+
+        RubyReactor::Dsl::InterruptStepConfig.new(step_config)
+      end
+    end
+  end
+end

--- a/lib/ruby_reactor/dsl/interrupt_step_config.rb
+++ b/lib/ruby_reactor/dsl/interrupt_step_config.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RubyReactor
+  module Dsl
+    class InterruptStepConfig < StepConfig
+      attr_reader :correlation_id_block, :timeout_config, :validation_schema, :strategy
+
+      def initialize(config)
+        super
+        @correlation_id_block = config[:correlation_id_block]
+        @timeout_config = config[:timeout_config]
+        @validation_schema = config[:validation_schema]
+      end
+
+      def interrupt?
+        true
+      end
+    end
+  end
+end

--- a/lib/ruby_reactor/dsl/reactor.rb
+++ b/lib/ruby_reactor/dsl/reactor.rb
@@ -18,6 +18,9 @@ module RubyReactor
         include RubyReactor::Dsl::TemplateHelpers
         include RubyReactor::Dsl::ValidationHelpers
 
+        require_relative "interrupt_builder"
+        require_relative "interrupt_step_config"
+
         def inputs
           @inputs ||= {}
         end
@@ -99,6 +102,15 @@ module RubyReactor
         def map(name, reactor_class = nil, &block)
           builder = RubyReactor::Dsl::MapBuilder.new(name, reactor_class, self, &block)
 
+          builder.instance_eval(&block) if block_given?
+
+          step_config = builder.build
+          steps[name] = step_config
+          step_config
+        end
+
+        def interrupt(name, &block)
+          builder = RubyReactor::Dsl::InterruptBuilder.new(name, self)
           builder.instance_eval(&block) if block_given?
 
           step_config = builder.build

--- a/lib/ruby_reactor/dsl/step_builder.rb
+++ b/lib/ruby_reactor/dsl/step_builder.rb
@@ -172,6 +172,10 @@ module RubyReactor
         @conditions.all? { |condition| condition.call(context) } &&
           @guards.all? { |guard| guard.call(context) }
       end
+
+      def interrupt?
+        false
+      end
     end
   end
 end

--- a/lib/ruby_reactor/executor.rb
+++ b/lib/ruby_reactor/executor.rb
@@ -44,6 +44,10 @@ module RubyReactor
       graph_manager.build_and_validate!
 
       @result = @step_executor.execute_all_steps
+
+      handle_interrupt(@result) if @result.is_a?(RubyReactor::InterruptResult)
+
+      @result
     rescue StandardError => e
       @result = @result_handler.handle_execution_error(e)
     end
@@ -118,6 +122,24 @@ module RubyReactor
                   @result_handler.handle_execution_error(error)
                 end
       @result
+    end
+
+    def handle_interrupt(interrupt_result)
+      storage = RubyReactor::Configuration.instance.storage_adapter
+      reactor_class_name = @reactor_class.name
+
+      # Serialize context
+      serialized_context = ContextSerializer.serialize(@context)
+      storage.store_context(@context.context_id, serialized_context, reactor_class_name)
+
+      # Store correlation ID mapping if present
+      return unless interrupt_result.correlation_id
+
+      storage.store_correlation_id(
+        interrupt_result.correlation_id,
+        @context.context_id,
+        reactor_class_name
+      )
     end
   end
 end

--- a/lib/ruby_reactor/executor.rb
+++ b/lib/ruby_reactor/executor.rb
@@ -64,6 +64,10 @@ module RubyReactor
       handle_resume_error(e)
     end
 
+    def undo_all
+      @compensation_manager.rollback_completed_steps
+    end
+
     def undo_stack
       @compensation_manager.undo_stack
     end

--- a/lib/ruby_reactor/executor.rb
+++ b/lib/ruby_reactor/executor.rb
@@ -86,7 +86,7 @@ module RubyReactor
 
     def save_context
       storage = RubyReactor::Configuration.instance.storage_adapter
-      reactor_class_name = @reactor_class.name
+      reactor_class_name = @reactor_class.name || "AnonymousReactor-#{@reactor_class.object_id}"
 
       # Serialize context
       serialized_context = ContextSerializer.serialize(@context)

--- a/lib/ruby_reactor/executor.rb
+++ b/lib/ruby_reactor/executor.rb
@@ -55,11 +55,15 @@ module RubyReactor
     def resume_execution
       prepare_for_resume
 
-      if @context.current_step
-        execute_current_step_and_continue
-      else
-        execute_remaining_steps
-      end
+      @result = if @context.current_step
+                  execute_current_step_and_continue
+                else
+                  execute_remaining_steps
+                end
+
+      handle_interrupt(@result) if @result.is_a?(RubyReactor::InterruptResult)
+
+      @result
     rescue StandardError => e
       handle_resume_error(e)
     end
@@ -78,6 +82,15 @@ module RubyReactor
 
     def execution_trace
       @context.execution_trace
+    end
+
+    def save_context
+      storage = RubyReactor::Configuration.instance.storage_adapter
+      reactor_class_name = @reactor_class.name
+
+      # Serialize context
+      serialized_context = ContextSerializer.serialize(@context)
+      storage.store_context(@context.context_id, serialized_context, reactor_class_name)
     end
 
     private
@@ -101,7 +114,7 @@ module RubyReactor
         @result = @step_executor.execute_all_steps
       else
         case result
-        when RetryQueuedResult, RubyReactor::Failure, RubyReactor::AsyncResult
+        when RetryQueuedResult, RubyReactor::Failure, RubyReactor::AsyncResult, RubyReactor::InterruptResult
           # Step was requeued, failed, or handed off to async - return the result
           @result = result
         when RubyReactor::Success
@@ -129,20 +142,16 @@ module RubyReactor
     end
 
     def handle_interrupt(interrupt_result)
-      storage = RubyReactor::Configuration.instance.storage_adapter
-      reactor_class_name = @reactor_class.name
-
-      # Serialize context
-      serialized_context = ContextSerializer.serialize(@context)
-      storage.store_context(@context.context_id, serialized_context, reactor_class_name)
+      save_context
 
       # Store correlation ID mapping if present
       return unless interrupt_result.correlation_id
 
+      storage = RubyReactor::Configuration.instance.storage_adapter
       storage.store_correlation_id(
         interrupt_result.correlation_id,
         @context.context_id,
-        reactor_class_name
+        @reactor_class.name
       )
     end
   end

--- a/lib/ruby_reactor/executor/compensation_manager.rb
+++ b/lib/ruby_reactor/executor/compensation_manager.rb
@@ -5,14 +5,17 @@ module RubyReactor
     class CompensationManager
       def initialize(context)
         @context = context
-        @undo_stack = []
         @undo_trace = []
       end
 
-      attr_reader :undo_stack, :undo_trace
+      def undo_stack
+        @context.undo_stack
+      end
+
+      attr_reader :undo_trace
 
       def add_to_undo_stack(step_info)
-        @undo_stack << step_info
+        @context.undo_stack << step_info
       end
 
       def handle_step_failure(step_config, error, arguments)
@@ -36,12 +39,12 @@ module RubyReactor
       end
 
       def rollback_completed_steps
-        @undo_stack.reverse_each do |step_info|
+        undo_stack.reverse_each do |step_info|
           result = undo_step(step_info[:step], step_info[:result], step_info[:arguments])
           @undo_trace << { type: :undo, step: step_info[:step].name, result: result,
                            arguments: step_info[:arguments] }
         end
-        @undo_stack.clear
+        undo_stack.clear
       end
 
       private

--- a/lib/ruby_reactor/executor/graph_manager.rb
+++ b/lib/ruby_reactor/executor/graph_manager.rb
@@ -3,6 +3,8 @@
 module RubyReactor
   class Executor
     class GraphManager
+      attr_reader :dependency_graph
+
       def initialize(reactor_class, dependency_graph, context)
         @reactor_class = reactor_class
         @dependency_graph = dependency_graph

--- a/lib/ruby_reactor/executor/step_executor.rb
+++ b/lib/ruby_reactor/executor/step_executor.rb
@@ -82,8 +82,10 @@ module RubyReactor
         # Update retry context
         @context.retry_context = other_executor.context.retry_context
 
-        # Clear current_step since we've completed it
-        @context.current_step = nil
+        # Update current_step:
+        # If the other executor has a current_step, it means it paused/interrupted there. We should adopt it.
+        # If it's nil, it means it completed successfully, so we clear our current_step (which was the async step).
+        @context.current_step = other_executor.context.current_step
 
         # Update our dependency graph to reflect completed steps
         other_executor.context.intermediate_results.each_key do |step_name|

--- a/lib/ruby_reactor/executor/step_executor.rb
+++ b/lib/ruby_reactor/executor/step_executor.rb
@@ -36,6 +36,9 @@ module RubyReactor
             # If a step returns Failure, we need to stop execution and return it
             return result if result.is_a?(RubyReactor::Failure)
 
+            # If a step returns InterruptResult, we need to stop execution and return it
+            return result if result.is_a?(RubyReactor::InterruptResult)
+
             # If result is nil, it means async was executed inline (test mode), continue
             next if result.nil?
           end
@@ -49,7 +52,9 @@ module RubyReactor
         # If we're already in inline async execution mode (inside Worker),
         # treat async steps as sync to avoid infinite recursion
 
-        if step_config.async? && !@context.inline_async_execution
+        if step_config.interrupt?
+          handle_interrupt_step(step_config)
+        elsif step_config.async? && !@context.inline_async_execution
           handle_async_step(step_config)
         else
           execute_step_with_retry(step_config)
@@ -246,6 +251,28 @@ module RubyReactor
         merge_executor_state(result)
 
         result.result
+      end
+
+      def handle_interrupt_step(step_config)
+        # Check if we have a result for this step (resuming)
+        if @context.intermediate_results.key?(step_config.name)
+          # We are resuming
+          result = @context.get_result(step_config.name)
+          return RubyReactor.Success(result)
+        end
+
+        # We are pausing
+        correlation_id = nil
+        correlation_id = step_config.correlation_id_block.call(@context) if step_config.correlation_id_block
+
+        # Store current step as the one we are paused at
+        @context.current_step = step_config.name
+
+        RubyReactor::InterruptResult.new(
+          execution_id: @context.context_id,
+          correlation_id: correlation_id,
+          intermediate_results: @context.intermediate_results
+        )
       end
 
       def configuration

--- a/lib/ruby_reactor/executor/step_executor.rb
+++ b/lib/ruby_reactor/executor/step_executor.rb
@@ -96,7 +96,8 @@ module RubyReactor
         # Merge any undo stack items
         other_executor.undo_stack.each do |item|
           # Avoid duplicates by checking if this step is already in the undo stack
-          unless @compensation_manager.undo_stack.any? { |existing| existing[:step].name == item[:step].name }
+          # Use string comparison for step names to avoid symbol/string mismatch issues
+          unless @compensation_manager.undo_stack.any? { |existing| existing[:step].name.to_s == item[:step].name.to_s }
             @compensation_manager.add_to_undo_stack(item)
           end
         end

--- a/lib/ruby_reactor/interrupt_result.rb
+++ b/lib/ruby_reactor/interrupt_result.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module RubyReactor
+  class InterruptResult
+    attr_reader :execution_id, :correlation_id, :status, :timeout_at, :intermediate_results
+
+    def initialize(execution_id:, correlation_id: nil, timeout_at: nil, intermediate_results: {})
+      @execution_id = execution_id
+      @correlation_id = correlation_id
+      @status = :paused
+      @timeout_at = timeout_at
+      @intermediate_results = intermediate_results
+    end
+
+    def paused?
+      true
+    end
+  end
+end

--- a/lib/ruby_reactor/map/collector.rb
+++ b/lib/ruby_reactor/map/collector.rb
@@ -5,7 +5,6 @@ module RubyReactor
     class Collector
       extend Helpers
 
-      # rubocop:disable Metrics/MethodLength
       def self.perform(arguments)
         arguments = arguments.transform_keys(&:to_sym)
         parent_context_id = arguments[:parent_context_id]
@@ -59,7 +58,6 @@ module RubyReactor
         # Resume execution
         resume_parent_execution(parent_context, step_name, final_result, storage)
       end
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/ruby_reactor/reactor.rb
+++ b/lib/ruby_reactor/reactor.rb
@@ -108,9 +108,18 @@ module RubyReactor
         raise Error::ValidationError, "Cannot resume: context does not have a current step (was it interrupted?)"
       end
 
-      # Validate step_name if provided
+      # Check if step_name is valid (current step OR ready step)
       if step_name && step_name.to_s != @context.current_step.to_s
-        raise Error::ValidationError, "Cannot resume: expected step '#{@context.current_step}' but got '#{step_name}'"
+        # Build graph to check if step is ready
+        graph_manager = Executor::GraphManager.new(self.class, DependencyGraph.new, @context)
+        graph_manager.build_and_validate!
+        graph_manager.mark_completed_steps_from_context
+        ready_steps = graph_manager.dependency_graph.ready_steps.map(&:name).map(&:to_s)
+
+        unless ready_steps.include?(step_name.to_s)
+          raise Error::ValidationError,
+                "Cannot resume: expected step '#{@context.current_step}' or ready steps #{ready_steps} but got '#{step_name}'"
+        end
       end
 
       # Validate payload if the step has validation
@@ -132,7 +141,8 @@ module RubyReactor
         end
       end
 
-      @context.set_result(@context.current_step, payload)
+      target_step = step_name || @context.current_step
+      @context.set_result(target_step, payload)
 
       # Resume execution
       executor = Executor.new(self.class, {}, @context)

--- a/lib/ruby_reactor/reactor.rb
+++ b/lib/ruby_reactor/reactor.rb
@@ -6,68 +6,63 @@ module RubyReactor
 
     attr_reader :context, :result, :undo_trace, :execution_trace
 
-    def self.continue(id:, payload:, idempotency_key: nil)
+    def self.find(id)
       reactor_class_name = name
       serialized_context = configuration.storage_adapter.retrieve_context(id, reactor_class_name)
       raise Error::ValidationError, "Context '#{id}' not found" unless serialized_context
 
       context = Context.deserialize_from_retry(serialized_context)
-
-      # TODO: Implement idempotency check using idempotency_key
-      _ = idempotency_key
-
-      resume_with_payload(context, payload)
+      new(context)
     end
 
-    def self.continue_by_correlation_id(correlation_id:, payload:, idempotency_key: nil)
+    def self.find_by_correlation_id(correlation_id)
       reactor_class_name = name
-      context_id = configuration.storage_adapter.retrieve_context_id_by_correlation_id(correlation_id,
-                                                                                       reactor_class_name)
+      context_id = configuration.storage_adapter.retrieve_context_id_by_correlation_id(
+        correlation_id,
+        reactor_class_name
+      )
       raise Error::ValidationError, "Correlation ID '#{correlation_id}' not found" unless context_id
 
-      continue(id: context_id, payload: payload, idempotency_key: idempotency_key)
+      find(context_id)
+    end
+
+    def self.continue(id:, payload:, step_name: nil, idempotency_key: nil)
+      reactor = find(id)
+      result = reactor.continue(payload: payload, step_name: step_name, idempotency_key: idempotency_key)
+
+      if result.is_a?(RubyReactor::Failure) && result.invalid_payload?
+        undo(id)
+        cancel(id: id, reason: "Payload validation failed")
+
+        # Raise exception to match expected behavior (strict mode for class method)
+        raise Error::InputValidationError.new(result.error)
+      end
+
+      result
+    end
+
+    def self.continue_by_correlation_id(correlation_id:, payload:, step_name: nil, idempotency_key: nil)
+      reactor = find_by_correlation_id(correlation_id)
+      # We delegate to the class-level continue method to ensure auto-compensation logic applies
+      # by using the context ID found by find_by_correlation_id
+      continue(id: reactor.context.context_id, payload: payload, step_name: step_name, idempotency_key: idempotency_key)
     end
 
     def self.cancel(id:, reason:)
-      # Placeholder for cancellation logic
-      # 1. Retrieve context
-      # 2. Mark as cancelled
-      # 3. Trigger compensations if needed
-      # 4. Clean up storage
-
       _ = reason
       reactor_class_name = name
-      # For now, just remove from storage
-      configuration.storage_adapter.expire(
-        "reactor:#{reactor_class_name}:context:#{id}",
-        0
-      )
+
+      # Clean up storage
+      configuration.storage_adapter.delete_context(id, reactor_class_name)
+
+      # We might want to remove correlation IDs too, but we don't always know them here easily
+      # unless we rehydrate the context. For now, we rely on TTL or separate cleanup.
     end
 
-    def self.resume_with_payload(context, payload)
-      # Store payload as the result of the current step (the interrupt step)
-      # The step name is stored in context.current_step
-
-      unless context.current_step
-        raise Error::ValidationError, "Cannot resume: context does not have a current step (was it interrupted?)"
-      end
-
-      # Validate payload if the step has validation
-      step_config = steps[context.current_step]
-      if step_config && step_config.validation_schema
-        validation = step_config.validation_schema.call(payload)
-        raise Error::InputValidationError, validation.errors.to_h if validation.failure?
-      end
-
-      context.set_result(context.current_step, payload)
-
-      # Resume execution
-      executor = Executor.new(self, {}, context)
-      executor.resume_execution
-
-      # Clean up correlation ID from storage if it exists?
-      # Maybe better to do this in Executor or keep it until TTL?
-      # For now, let's leave it to expire.
+    def self.undo(id)
+      reactor = find(id)
+      reactor.undo
+      cancel(id: id, reason: "Undo triggered")
     end
 
     def self.configuration
@@ -89,11 +84,13 @@ module RubyReactor
         configuration.async_router.perform_async(serialized_context)
       else
         # For sync reactors (potentially with async steps), execute normally
-        executor = Executor.new(self.class, inputs)
+        context = @context.is_a?(Context) ? @context : nil
+        executor = Executor.new(self.class, inputs, context)
         @result = executor.execute
 
         @context = executor.context
 
+        # Merge traces
         @undo_trace = executor.undo_trace
         @execution_trace = executor.execution_trace
 
@@ -102,6 +99,61 @@ module RubyReactor
 
         @result
       end
+    end
+
+    def continue(payload:, step_name: nil, idempotency_key: nil)
+      _ = idempotency_key
+
+      unless @context.current_step
+        raise Error::ValidationError, "Cannot resume: context does not have a current step (was it interrupted?)"
+      end
+
+      # Validate step_name if provided
+      if step_name && step_name.to_s != @context.current_step.to_s
+        raise Error::ValidationError, "Cannot resume: expected step '#{@context.current_step}' but got '#{step_name}'"
+      end
+
+      # Validate payload if the step has validation
+      step_config = self.class.steps[@context.current_step]
+      if step_config && step_config.validation_schema
+        validation = step_config.validation_schema.call(payload)
+
+        if validation.failure?
+          failure = RubyReactor::Failure(validation.errors.to_h)
+          # We need a way to mark this failure as a validation failure
+          # For now, we rely on the error object inside Failure or just return Failure
+          # The PRD requires `result.invalid_payload?` to be true.
+          # Since we don't have that method on Failure yet, we might need to enhance Failure
+          # OR wrap it. For now, let's assume Failure wraps the error and we can check it.
+          # We'll use a specific error type to identify it.
+          failure.instance_variable_set(:@type, :input_validation)
+          def failure.invalid_payload? = true
+          return failure
+        end
+      end
+
+      @context.set_result(@context.current_step, payload)
+
+      # Resume execution
+      executor = Executor.new(self.class, {}, @context)
+      @result = executor.resume_execution
+
+      @context = executor.context
+      @undo_trace = executor.undo_trace
+      @execution_trace = executor.execution_trace
+
+      @result
+    rescue Error::InputValidationError => e
+      # This might catch other validations, but here we specifically want payload validation.
+      # The block above handles payload validation explicitly.
+      failure = RubyReactor::Failure(e.message)
+      def failure.invalid_payload? = true
+      failure
+    end
+
+    def undo
+      executor = Executor.new(self.class, {}, @context)
+      executor.undo_all
     end
 
     def validate!

--- a/lib/ruby_reactor/reactor.rb
+++ b/lib/ruby_reactor/reactor.rb
@@ -26,7 +26,7 @@ module RubyReactor
       find(context_id)
     end
 
-    def self.continue(id:, payload:, step_name: nil, idempotency_key: nil)
+    def self.continue(id:, payload:, step_name:, idempotency_key: nil)
       reactor = find(id)
       result = reactor.continue(payload: payload, step_name: step_name, idempotency_key: idempotency_key)
 
@@ -41,7 +41,7 @@ module RubyReactor
       result
     end
 
-    def self.continue_by_correlation_id(correlation_id:, payload:, step_name: nil, idempotency_key: nil)
+    def self.continue_by_correlation_id(correlation_id:, payload:, step_name:, idempotency_key: nil)
       reactor = find_by_correlation_id(correlation_id)
       # We delegate to the class-level continue method to ensure auto-compensation logic applies
       # by using the context ID found by find_by_correlation_id
@@ -101,7 +101,7 @@ module RubyReactor
       end
     end
 
-    def continue(payload:, step_name: nil, idempotency_key: nil)
+    def continue(payload:, step_name:, idempotency_key: nil)
       _ = idempotency_key
 
       unless @context.current_step
@@ -109,7 +109,7 @@ module RubyReactor
       end
 
       # Check if step_name is valid (current step OR ready step)
-      if step_name && step_name.to_s != @context.current_step.to_s
+      if step_name.to_s != @context.current_step.to_s
         # Build graph to check if step is ready
         graph_manager = Executor::GraphManager.new(self.class, DependencyGraph.new, @context)
         graph_manager.build_and_validate!
@@ -141,7 +141,7 @@ module RubyReactor
         end
       end
 
-      target_step = step_name || @context.current_step
+      target_step = step_name
       @context.set_result(target_step, payload)
 
       # Resume execution

--- a/lib/ruby_reactor/reactor.rb
+++ b/lib/ruby_reactor/reactor.rb
@@ -49,14 +49,8 @@ module RubyReactor
     end
 
     def self.cancel(id:, reason:)
-      _ = reason
-      reactor_class_name = name
-
-      # Clean up storage
-      configuration.storage_adapter.delete_context(id, reactor_class_name)
-
-      # We might want to remove correlation IDs too, but we don't always know them here easily
-      # unless we rehydrate the context. For now, we rely on TTL or separate cleanup.
+      reactor = find(id)
+      reactor.cancel(reason)
     end
 
     def self.undo(id)
@@ -108,6 +102,11 @@ module RubyReactor
         raise Error::ValidationError, "Cannot resume: context does not have a current step (was it interrupted?)"
       end
 
+      if @context.cancelled
+        raise Error::ValidationError,
+              "Cannot resume: reactor has been cancelled (Reason: #{@context.cancellation_reason})"
+      end
+
       validate_continue_step!(step_name)
 
       if (failure = validate_continue_payload(payload))
@@ -137,6 +136,13 @@ module RubyReactor
     def undo
       executor = Executor.new(self.class, {}, @context)
       executor.undo_all
+      executor.save_context
+    end
+
+    def cancel(reason)
+      @context.cancelled = true
+      @context.cancellation_reason = reason
+      save_context
     end
 
     def validate!
@@ -209,6 +215,13 @@ module RubyReactor
       failure.instance_variable_set(:@type, :input_validation)
       def failure.invalid_payload? = true
       failure
+    end
+
+    def save_context
+      storage = configuration.storage_adapter
+      reactor_class_name = self.class.name || "AnonymousReactor-#{self.class.object_id}"
+      serialized_context = ContextSerializer.serialize(@context)
+      storage.store_context(@context.context_id, serialized_context, reactor_class_name)
     end
   end
 end

--- a/lib/ruby_reactor/reactor.rb
+++ b/lib/ruby_reactor/reactor.rb
@@ -35,7 +35,7 @@ module RubyReactor
         cancel(id: id, reason: "Payload validation failed")
 
         # Raise exception to match expected behavior (strict mode for class method)
-        raise Error::InputValidationError.new(result.error)
+        raise Error::InputValidationError, result.error
       end
 
       result
@@ -124,7 +124,7 @@ module RubyReactor
 
       # Validate payload if the step has validation
       step_config = self.class.steps[@context.current_step]
-      if step_config && step_config.validation_schema
+      if step_config&.validation_schema
         validation = step_config.validation_schema.call(payload)
 
         if validation.failure?

--- a/lib/ruby_reactor/reactor.rb
+++ b/lib/ruby_reactor/reactor.rb
@@ -6,6 +6,74 @@ module RubyReactor
 
     attr_reader :context, :result, :undo_trace, :execution_trace
 
+    def self.continue(id:, payload:, idempotency_key: nil)
+      reactor_class_name = name
+      serialized_context = configuration.storage_adapter.retrieve_context(id, reactor_class_name)
+      raise Error::ValidationError, "Context '#{id}' not found" unless serialized_context
+
+      context = Context.deserialize_from_retry(serialized_context)
+
+      # TODO: Implement idempotency check using idempotency_key
+      _ = idempotency_key
+
+      resume_with_payload(context, payload)
+    end
+
+    def self.continue_by_correlation_id(correlation_id:, payload:, idempotency_key: nil)
+      reactor_class_name = name
+      context_id = configuration.storage_adapter.retrieve_context_id_by_correlation_id(correlation_id,
+                                                                                       reactor_class_name)
+      raise Error::ValidationError, "Correlation ID '#{correlation_id}' not found" unless context_id
+
+      continue(id: context_id, payload: payload, idempotency_key: idempotency_key)
+    end
+
+    def self.cancel(id:, reason:)
+      # Placeholder for cancellation logic
+      # 1. Retrieve context
+      # 2. Mark as cancelled
+      # 3. Trigger compensations if needed
+      # 4. Clean up storage
+
+      _ = reason
+      reactor_class_name = name
+      # For now, just remove from storage
+      configuration.storage_adapter.expire(
+        "reactor:#{reactor_class_name}:context:#{id}",
+        0
+      )
+    end
+
+    def self.resume_with_payload(context, payload)
+      # Store payload as the result of the current step (the interrupt step)
+      # The step name is stored in context.current_step
+
+      unless context.current_step
+        raise Error::ValidationError, "Cannot resume: context does not have a current step (was it interrupted?)"
+      end
+
+      # Validate payload if the step has validation
+      step_config = steps[context.current_step]
+      if step_config && step_config.validation_schema
+        validation = step_config.validation_schema.call(payload)
+        raise Error::InputValidationError, validation.errors.to_h if validation.failure?
+      end
+
+      context.set_result(context.current_step, payload)
+
+      # Resume execution
+      executor = Executor.new(self, {}, context)
+      executor.resume_execution
+
+      # Clean up correlation ID from storage if it exists?
+      # Maybe better to do this in Executor or keep it until TTL?
+      # For now, let's leave it to expire.
+    end
+
+    def self.configuration
+      RubyReactor::Configuration.instance
+    end
+
     def initialize(context = {})
       @context = context
       @result = :unexecuted

--- a/lib/ruby_reactor/reactor.rb
+++ b/lib/ruby_reactor/reactor.rb
@@ -108,37 +108,10 @@ module RubyReactor
         raise Error::ValidationError, "Cannot resume: context does not have a current step (was it interrupted?)"
       end
 
-      # Check if step_name is valid (current step OR ready step)
-      if step_name.to_s != @context.current_step.to_s
-        # Build graph to check if step is ready
-        graph_manager = Executor::GraphManager.new(self.class, DependencyGraph.new, @context)
-        graph_manager.build_and_validate!
-        graph_manager.mark_completed_steps_from_context
-        ready_steps = graph_manager.dependency_graph.ready_steps.map(&:name).map(&:to_s)
+      validate_continue_step!(step_name)
 
-        unless ready_steps.include?(step_name.to_s)
-          raise Error::ValidationError,
-                "Cannot resume: expected step '#{@context.current_step}' or ready steps #{ready_steps} but got '#{step_name}'"
-        end
-      end
-
-      # Validate payload if the step has validation
-      step_config = self.class.steps[@context.current_step]
-      if step_config&.validation_schema
-        validation = step_config.validation_schema.call(payload)
-
-        if validation.failure?
-          failure = RubyReactor::Failure(validation.errors.to_h)
-          # We need a way to mark this failure as a validation failure
-          # For now, we rely on the error object inside Failure or just return Failure
-          # The PRD requires `result.invalid_payload?` to be true.
-          # Since we don't have that method on Failure yet, we might need to enhance Failure
-          # OR wrap it. For now, let's assume Failure wraps the error and we can check it.
-          # We'll use a specific error type to identify it.
-          failure.instance_variable_set(:@type, :input_validation)
-          def failure.invalid_payload? = true
-          return failure
-        end
+      if (failure = validate_continue_payload(payload))
+        return failure
       end
 
       target_step = step_name
@@ -200,6 +173,42 @@ module RubyReactor
       return unless graph.has_cycles?
 
       raise Error::DependencyError, "Dependency graph contains cycles"
+    end
+
+    def validate_continue_step!(step_name)
+      return if step_name.to_s == @context.current_step.to_s
+
+      # Build graph to check if step is ready
+      graph_manager = Executor::GraphManager.new(self.class, DependencyGraph.new, @context)
+      graph_manager.build_and_validate!
+      graph_manager.mark_completed_steps_from_context
+      ready_steps = graph_manager.dependency_graph.ready_steps.map(&:name).map(&:to_s)
+
+      return if ready_steps.include?(step_name.to_s)
+
+      raise Error::ValidationError,
+            "Cannot resume: expected step '#{@context.current_step}' " \
+            "or ready steps #{ready_steps} but got '#{step_name}'"
+    end
+
+    def validate_continue_payload(payload)
+      step_config = self.class.steps[@context.current_step]
+      return unless step_config&.validation_schema
+
+      validation = step_config.validation_schema.call(payload)
+
+      return unless validation.failure?
+
+      failure = RubyReactor::Failure(validation.errors.to_h)
+      # We need a way to mark this failure as a validation failure
+      # For now, we rely on the error object inside Failure or just return Failure
+      # The PRD requires `result.invalid_payload?` to be true.
+      # Since we don't have that method on Failure yet, we might need to enhance Failure
+      # OR wrap it. For now, let's assume Failure wraps the error and we can check it.
+      # We'll use a specific error type to identify it.
+      failure.instance_variable_set(:@type, :input_validation)
+      def failure.invalid_payload? = true
+      failure
     end
   end
 end

--- a/lib/ruby_reactor/sidekiq_workers/worker.rb
+++ b/lib/ruby_reactor/sidekiq_workers/worker.rb
@@ -37,10 +37,8 @@ module RubyReactor
 
         # Resume execution from the failed step
         executor = Executor.new(context.reactor_class, {}, context)
-        # executor.compensation_manager.undo_stack is already referencing context.undo_stack
-        # because CompensationManager uses the context instance passed to Executor.
-        # Removing the explicit concat fixes the duplication issue.
         executor.resume_execution
+        executor.save_context
 
         # Return the executor (which now has the result stored in it)
         executor

--- a/lib/ruby_reactor/sidekiq_workers/worker.rb
+++ b/lib/ruby_reactor/sidekiq_workers/worker.rb
@@ -37,7 +37,9 @@ module RubyReactor
 
         # Resume execution from the failed step
         executor = Executor.new(context.reactor_class, {}, context)
-        executor.compensation_manager.undo_stack.concat(context.undo_stack)
+        # executor.compensation_manager.undo_stack is already referencing context.undo_stack
+        # because CompensationManager uses the context instance passed to Executor.
+        # Removing the explicit concat fixes the duplication issue.
         executor.resume_execution
 
         # Return the executor (which now has the result stored in it)

--- a/lib/ruby_reactor/storage/adapter.rb
+++ b/lib/ruby_reactor/storage/adapter.rb
@@ -46,6 +46,18 @@ module RubyReactor
       def expire(key, seconds)
         raise NotImplementedError
       end
+
+      def store_correlation_id(correlation_id, context_id, reactor_class_name)
+        raise NotImplementedError
+      end
+
+      def retrieve_context_id_by_correlation_id(correlation_id, reactor_class_name)
+        raise NotImplementedError
+      end
+
+      def delete_correlation_id(correlation_id, reactor_class_name)
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/lib/ruby_reactor/storage/adapter.rb
+++ b/lib/ruby_reactor/storage/adapter.rb
@@ -58,6 +58,10 @@ module RubyReactor
       def delete_correlation_id(correlation_id, reactor_class_name)
         raise NotImplementedError
       end
+
+      def delete_context(context_id, reactor_class_name)
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/lib/ruby_reactor/storage/redis_adapter.rb
+++ b/lib/ruby_reactor/storage/redis_adapter.rb
@@ -106,6 +106,24 @@ module RubyReactor
         @redis.incr(key)
       end
 
+      def store_correlation_id(correlation_id, context_id, reactor_class_name)
+        key = correlation_id_key(correlation_id, reactor_class_name)
+        # Store mapping correlation_id -> context_id
+        success = @redis.set(key, context_id, nx: true, ex: 86_400) # 24h TTL, fail if exists
+
+        raise Error::ValidationError, "Correlation ID '#{correlation_id}' already exists" unless success
+      end
+
+      def retrieve_context_id_by_correlation_id(correlation_id, reactor_class_name)
+        key = correlation_id_key(correlation_id, reactor_class_name)
+        @redis.get(key)
+      end
+
+      def delete_correlation_id(correlation_id, reactor_class_name)
+        key = correlation_id_key(correlation_id, reactor_class_name)
+        @redis.del(key)
+      end
+
       def subscribe(channel, &block)
         @redis.subscribe(channel, &block)
       end
@@ -134,6 +152,10 @@ module RubyReactor
 
       def map_last_queued_index_key(map_id, reactor_class_name)
         "reactor:#{reactor_class_name}:map:#{map_id}:last_queued_index"
+      end
+
+      def correlation_id_key(correlation_id, reactor_class_name)
+        "reactor:#{reactor_class_name}:correlation:#{correlation_id}"
       end
     end
   end

--- a/lib/ruby_reactor/storage/redis_adapter.rb
+++ b/lib/ruby_reactor/storage/redis_adapter.rb
@@ -124,6 +124,11 @@ module RubyReactor
         @redis.del(key)
       end
 
+      def delete_context(context_id, reactor_class_name)
+        key = context_key(context_id, reactor_class_name)
+        @redis.del(key)
+      end
+
       def subscribe(channel, &block)
         @redis.subscribe(channel, &block)
       end

--- a/spec/async_retry_integration_spec.rb
+++ b/spec/async_retry_integration_spec.rb
@@ -76,16 +76,20 @@ RSpec.describe "RubyReactor Async and Retry Integration" do
 
     it "requeues jobs for async step retries instead of executing inline" do
       # Create a reactor with an async step that will fail
-      reactor_class = Class.new(RubyReactor::Reactor) do
-        step :failing_async_step do
-          async true
-          retries max_attempts: 3, backoff: :fixed, base_delay: 1
+      unless defined?(FailingAsyncRetryReactor)
+        FailingAsyncRetryReactor = Class.new(RubyReactor::Reactor) do
+          step :failing_async_step do
+            async true
+            retries max_attempts: 3, backoff: :fixed, base_delay: 1
 
-          run do |_args, _context|
-            RubyReactor::Failure("Step always fails")
+            run do |_args, _context|
+              RubyReactor::Failure("Step always fails")
+            end
           end
         end
       end
+
+      reactor_class = FailingAsyncRetryReactor
 
       reactor = reactor_class.new
 

--- a/spec/ruby_reactor/async_notification_interrupt_spec.rb
+++ b/spec/ruby_reactor/async_notification_interrupt_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Async Notification Interrupt Reactor" do
+  let(:reactor_class) { AsyncNotificationInterruptReactor }
+
+  before do
+    reactor_class.instance_variable_set(:@trace, [])
+    # Clear Redis
+    RubyReactor::Configuration.instance.storage_adapter.respond_to?(:flushdb) &&
+      RubyReactor::Configuration.instance.storage_adapter.flushdb
+
+    # Ensure sidekiq testing is in inline mode to simulate async job running immediately
+    # OR we can control it manually
+    Sidekiq::Testing.inline!
+  end
+
+  after do
+    Sidekiq::Testing.fake!
+  end
+
+  it "executes async step then pauses for interrupt and resumes" do
+    # 1. Run reactor
+    # retrieve_context (sync) -> send_notifications (async) -> manager_approval (interrupt)
+    # Sidekiq::Testing.inline! means the async job runs synchronously.
+    # However, AsyncRouter still returns AsyncResult packaging the job_id.
+
+    execution = reactor_class.run
+
+    # In default test env (WorkerMock), run returns the result directly because it executes inline
+    expect(execution).to be_a(RubyReactor::InterruptResult)
+    execution_id = execution.execution_id
+
+    # Verify trace (inline execution happened)
+    expect(reactor_class.trace).to eq(%i[retrieve_context send_notifications])
+
+    # 2. Check stored state
+    stored_context = RubyReactor::Configuration.instance.storage_adapter.retrieve_context(execution_id,
+                                                                                          reactor_class.name)
+    expect(stored_context).not_to be_nil
+
+    # 3. Resume with approval
+    # This resumes 'manager_approval'.
+    # Then 'process_approval' runs. It is ALSO async.
+    # So continue will return AsyncResult.
+    result = reactor_class.continue(
+      id: execution_id,
+      step_name: :manager_approval,
+      payload: { status: "approved" }
+    )
+
+    # In default test env (WorkerMock), continue runs the async step inline and returns the result (Success)
+    expect(result).to be_a(RubyReactor::Success)
+
+    # Inline execution should have completed 'process_approval'
+    expect(reactor_class.trace).to eq(%i[retrieve_context send_notifications process_approval])
+
+    expect(result.value).to eq("processed_approved_after_notifications_sent_to_123")
+
+    # Verify final result by reloading context or checking return value if we could (but AsyncResult hides it)
+    reactor = reactor_class.find(execution_id)
+    # The context should have the results set
+    expect(reactor.context.result(:manager_approval)).to eq({ status: "approved" })
+
+    # process_approval result would be in intermediate_results
+    process_result = reactor.context.result(:process_approval)
+    # NOTE: process_approval result depends on argument interpolation which we fixed
+    expect(process_result).to eq("processed_approved_after_notifications_sent_to_123")
+  end
+
+  context "with manual async execution" do
+    before do
+      # Use real AsyncRouter to test actual Sidekiq queuing
+      allow(RubyReactor::Configuration.instance).to receive(:async_router).and_return(RubyReactor::AsyncRouter)
+    end
+
+    it "returns AsyncResult initially, then pauses at interrupt after worker runs" do
+      # Force fake mode to ensure job is queued not executed
+      Sidekiq::Testing.fake! do
+        # 1. Run reactor -> retrieve_context (sync) -> send_notifications (async queued)
+        result = reactor_class.run
+
+        # Should return AsyncResult because send_notifications is async
+        expect(result).to be_a(RubyReactor::AsyncResult)
+        execution_id = result.execution_id
+
+        expect(reactor_class.trace).to eq([:retrieve_context])
+
+        # 2. Drain Sidekiq jobs to run send_notifications
+        # This runs send_notifications and pauses at manager_approval
+        RubyReactor::SidekiqWorkers::Worker.drain
+
+        expect(reactor_class.trace).to eq(%i[retrieve_context send_notifications])
+
+        # 3. Resume with approval
+        # Resumes manager_approval -> queues process_approval (async)
+        resume_result = reactor_class.continue(
+          id: execution_id,
+          step_name: :manager_approval,
+          payload: { status: "approved" }
+        )
+
+        expect(resume_result).to be_a(RubyReactor::AsyncResult)
+
+        # process_approval hasn't run yet (it's queued)
+        expect(reactor_class.trace).to eq(%i[retrieve_context send_notifications])
+
+        # 4. Drain again to run process_approval
+        RubyReactor::SidekiqWorkers::Worker.drain
+
+        expect(reactor_class.trace).to eq(%i[retrieve_context send_notifications process_approval])
+
+        # Verify final result
+        reactor = reactor_class.find(execution_id)
+        process_result = reactor.context.result(:process_approval)
+        expect(process_result).to eq("processed_approved_after_notifications_sent_to_123")
+      end
+    end
+  end
+end

--- a/spec/ruby_reactor/interrupt_spec.rb
+++ b/spec/ruby_reactor/interrupt_spec.rb
@@ -9,37 +9,6 @@ RSpec.describe "RubyReactor Interrupt Feature", type: :integration do
     redis.flushdb
   end
 
-  class TestInterruptReactor < RubyReactor::Reactor
-    input :user_id
-
-    step :prepare do
-      argument :user_id, input(:user_id)
-      run do |args|
-        Success("prepared-#{args[:user_id]}")
-      end
-    end
-
-    interrupt :wait_for_approval do
-      wait_for :prepare
-
-      correlation_id do |context|
-        "approval-#{context.result(:prepare)}"
-      end
-
-      validate do
-        required(:status).filled(:string)
-        required(:approver).filled(:string)
-      end
-    end
-
-    step :finalize do
-      argument :approval_data, result(:wait_for_approval)
-      run do |args|
-        Success("finalized-#{args[:approval_data][:status]}-by-#{args[:approval_data][:approver]}")
-      end
-    end
-  end
-
   describe "execution flow" do
     it "pauses at interrupt step and resumes with payload" do
       # 1. Start execution
@@ -66,7 +35,6 @@ RSpec.describe "RubyReactor Interrupt Feature", type: :integration do
       result = TestInterruptReactor.continue(id: context_id, payload: payload)
 
       # 5. Verify completion
-      # 5. Verify completion
       expect(result).to be_a(RubyReactor::Success)
       expect(result.value[:finalize]).to eq("finalized-approved-by-admin")
     end
@@ -83,7 +51,6 @@ RSpec.describe "RubyReactor Interrupt Feature", type: :integration do
         payload: payload
       )
 
-      # 3. Verify completion
       # 3. Verify completion
       expect(result).to be_a(RubyReactor::Success)
       expect(result.value[:finalize]).to eq("finalized-rejected-by-system")

--- a/spec/ruby_reactor/interrupt_spec.rb
+++ b/spec/ruby_reactor/interrupt_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "RubyReactor Interrupt Feature", type: :integration do
+  let(:redis) { Redis.new(url: "redis://localhost:6780") }
+
+  before do
+    redis.flushdb
+  end
+
+  class TestInterruptReactor < RubyReactor::Reactor
+    input :user_id
+
+    step :prepare do
+      argument :user_id, input(:user_id)
+      run do |args|
+        Success("prepared-#{args[:user_id]}")
+      end
+    end
+
+    interrupt :wait_for_approval do
+      wait_for :prepare
+
+      correlation_id do |context|
+        "approval-#{context.result(:prepare)}"
+      end
+
+      validate do
+        required(:status).filled(:string)
+        required(:approver).filled(:string)
+      end
+    end
+
+    step :finalize do
+      argument :approval_data, result(:wait_for_approval)
+      run do |args|
+        Success("finalized-#{args[:approval_data][:status]}-by-#{args[:approval_data][:approver]}")
+      end
+    end
+  end
+
+  describe "execution flow" do
+    it "pauses at interrupt step and resumes with payload" do
+      # 1. Start execution
+      execution = TestInterruptReactor.run(user_id: "123")
+
+      # 2. Verify it paused
+      expect(execution).to be_a(RubyReactor::InterruptResult)
+      expect(execution.status).to eq(:paused)
+      expect(execution.status).to eq(:paused)
+      expect(execution.correlation_id).to eq("approval-prepared-123")
+      expect(execution.intermediate_results).to include(prepare: "prepared-123")
+
+      # 3. Verify state in Redis
+      context_id = execution.execution_id
+      stored_context = redis.call("JSON.GET", "reactor:TestInterruptReactor:context:#{context_id}")
+      expect(stored_context).not_to be_nil
+
+      # Verify correlation ID mapping
+      stored_id = redis.get("reactor:TestInterruptReactor:correlation:approval-prepared-123")
+      expect(stored_id).to eq(context_id)
+
+      # 4. Resume execution via continue
+      payload = { status: "approved", approver: "admin" }
+      result = TestInterruptReactor.continue(id: context_id, payload: payload)
+
+      # 5. Verify completion
+      # 5. Verify completion
+      expect(result).to be_a(RubyReactor::Success)
+      expect(result.value[:finalize]).to eq("finalized-approved-by-admin")
+    end
+
+    it "resumes via correlation_id" do
+      # 1. Start execution
+      execution = TestInterruptReactor.run(user_id: "456")
+      expect(execution).to be_a(RubyReactor::InterruptResult)
+
+      # 2. Resume via correlation_id
+      payload = { status: "rejected", approver: "system" }
+      result = TestInterruptReactor.continue_by_correlation_id(
+        correlation_id: "approval-prepared-456",
+        payload: payload
+      )
+
+      # 3. Verify completion
+      # 3. Verify completion
+      expect(result).to be_a(RubyReactor::Success)
+      expect(result.value[:finalize]).to eq("finalized-rejected-by-system")
+    end
+
+    it "validates payload on resume" do
+      execution = TestInterruptReactor.run(user_id: "789")
+
+      # Invalid payload (missing approver)
+      payload = { status: "approved" }
+
+      expect do
+        TestInterruptReactor.continue(id: execution.execution_id, payload: payload)
+      end.to raise_error(RubyReactor::Error::InputValidationError)
+    end
+  end
+end

--- a/spec/ruby_reactor/interrupt_spec.rb
+++ b/spec/ruby_reactor/interrupt_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "RubyReactor Interrupt Feature", type: :integration do
 
       # 4. Resume execution via continue
       payload = { status: "approved", approver: "admin" }
-      result = TestInterruptReactor.continue(id: context_id, payload: payload)
+      result = TestInterruptReactor.continue(id: context_id, payload: payload, step_name: :wait_for_approval)
 
       # 5. Verify completion
       expect(result).to be_a(RubyReactor::Success)
@@ -48,7 +48,8 @@ RSpec.describe "RubyReactor Interrupt Feature", type: :integration do
       payload = { status: "rejected", approver: "system" }
       result = TestInterruptReactor.continue_by_correlation_id(
         correlation_id: "approval-prepared-456",
-        payload: payload
+        payload: payload,
+        step_name: :wait_for_approval
       )
 
       # 3. Verify completion
@@ -63,7 +64,7 @@ RSpec.describe "RubyReactor Interrupt Feature", type: :integration do
       payload = { status: "approved" }
 
       expect do
-        TestInterruptReactor.continue(id: execution.execution_id, payload: payload)
+        TestInterruptReactor.continue(id: execution.execution_id, payload: payload, step_name: :wait_for_approval)
       end.to raise_error(RubyReactor::Error::InputValidationError)
     end
   end

--- a/spec/ruby_reactor/interrupt_undo_spec.rb
+++ b/spec/ruby_reactor/interrupt_undo_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Interrupt Compensation and Undo" do
       it "automatically undos and cancels on invalid payload" do
         # Action & Assertion
         expect do
-          reactor_class.continue(id: execution_id, payload: { status: "invalid" })
+          reactor_class.continue(id: execution_id, payload: { status: "invalid" }, step_name: :wait_for_input)
         end.to raise_error(RubyReactor::Error::InputValidationError)
 
         expect(reactor_class.trace).to include(:prepare_undo)
@@ -38,7 +38,7 @@ RSpec.describe "Interrupt Compensation and Undo" do
       end
 
       it "resumes successfully on valid payload" do
-        result = reactor_class.continue(id: execution_id, payload: { status: "ok" })
+        result = reactor_class.continue(id: execution_id, payload: { status: "ok" }, step_name: :wait_for_input)
 
         expect(result).to be_a(RubyReactor::Success)
         expect(reactor_class.trace).to include(:process_run)
@@ -50,7 +50,7 @@ RSpec.describe "Interrupt Compensation and Undo" do
       it "returns invalid_payload result WITHOUT undo" do
         reactor = reactor_class.find(execution_id)
 
-        result = reactor.continue(payload: { status: "invalid" })
+        result = reactor.continue(payload: { status: "invalid" }, step_name: :wait_for_input)
 
         expect(result).to be_a(RubyReactor::Failure)
         expect(result.invalid_payload?).to be true

--- a/spec/ruby_reactor/interrupt_undo_spec.rb
+++ b/spec/ruby_reactor/interrupt_undo_spec.rb
@@ -34,7 +34,10 @@ RSpec.describe "Interrupt Compensation and Undo" do
         expect(reactor_class.trace).to include(:prepare_undo)
 
         stored = RubyReactor::Configuration.instance.storage_adapter.retrieve_context(execution_id, reactor_class.name)
-        expect(stored).to be_nil
+        expect(stored).not_to be_nil
+        context = RubyReactor::Context.deserialize_from_retry(stored)
+        # Check against string keys because deserialization might result in strings for hash values
+        expect(context.execution_trace).to include(hash_including(type: "undo", step: "prepare"))
       end
 
       it "resumes successfully on valid payload" do
@@ -80,7 +83,7 @@ RSpec.describe "Interrupt Compensation and Undo" do
       expect(reactor_class.trace).to include(:prepare_undo)
 
       stored = RubyReactor::Configuration.instance.storage_adapter.retrieve_context(execution_id, reactor_class.name)
-      expect(stored).to be_nil
+      expect(stored).not_to be_nil
     end
   end
 
@@ -88,13 +91,26 @@ RSpec.describe "Interrupt Compensation and Undo" do
     let(:execution) { reactor_class.run }
     let(:execution_id) { execution.execution_id }
 
-    it "deletes execution WITHOUT compensation" do
+    it "cancels execution WITHOUT compensation but preserves context with reason" do
       reactor_class.cancel(id: execution_id, reason: "Manual cancel")
 
       stored = RubyReactor::Configuration.instance.storage_adapter.retrieve_context(execution_id, reactor_class.name)
-      expect(stored).to be_nil
+      expect(stored).not_to be_nil
+
+      context = RubyReactor::Context.deserialize_from_retry(stored)
+      expect(context.cancelled).to be true
+      expect(context.cancellation_reason).to eq("Manual cancel")
 
       expect(reactor_class.trace).not_to include(:prepare_undo)
+    end
+
+    it "prevents continue after cancellation" do
+      reactor_class.cancel(id: execution_id, reason: "Manual cancel")
+
+      expect do
+        reactor_class.continue(id: execution_id, payload: {}, step_name: :wait_for_input)
+      end.to raise_error(RubyReactor::Error::ValidationError,
+                         /Cannot resume: reactor has been cancelled \(Reason: Manual cancel\)/)
     end
 
     context "with Explicit Step Validation" do

--- a/spec/ruby_reactor/interrupt_undo_spec.rb
+++ b/spec/ruby_reactor/interrupt_undo_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Define named class globally so persistence via name works
+class InterruptUndoTestReactor < RubyReactor::Reactor
+  def self.trace
+    @trace ||= []
+  end
+
+  step :prepare do
+    run do |_args, context|
+      context.reactor_class.trace << :prepare_run
+      Success("prep")
+    end
+
+    undo do |_result, _args, context|
+      context.reactor_class.trace << :prepare_undo
+      Success()
+    end
+  end
+
+  interrupt :wait_for_input do
+    wait_for :prepare
+
+    validate do
+      required(:status).filled(:string, eql?: "ok")
+    end
+  end
+
+  step :process do
+    argument :payload, result(:wait_for_input)
+
+    run do |args, context|
+      context.reactor_class.trace << :process_run
+      Success(args[:payload])
+    end
+  end
+
+  returns :process
+end
+
+RSpec.describe "Interrupt Compensation and Undo" do
+  let(:reactor_class) { InterruptUndoTestReactor }
+
+  before do
+    # Clear trace/redis
+    reactor_class.instance_variable_set(:@trace, [])
+    # Clear Redis
+    RubyReactor::Configuration.instance.storage_adapter.respond_to?(:flushdb) &&
+      RubyReactor::Configuration.instance.storage_adapter.flushdb
+  end
+
+  describe "Validation Failure" do
+    let(:execution) { reactor_class.run }
+    let(:execution_id) do
+      execution.execution_id
+    end
+
+    before do
+      expect(execution).to be_a(RubyReactor::InterruptResult)
+      expect(reactor_class.trace).to eq([:prepare_run])
+    end
+
+    context "via Reactor.continue (Class method)" do
+      it "automatically undos and cancels on invalid payload" do
+        # Action & Assertion
+        expect do
+          reactor_class.continue(id: execution_id, payload: { status: "invalid" })
+        end.to raise_error(RubyReactor::Error::InputValidationError)
+
+        expect(reactor_class.trace).to include(:prepare_undo)
+
+        stored = RubyReactor::Configuration.instance.storage_adapter.retrieve_context(execution_id, reactor_class.name)
+        expect(stored).to be_nil
+      end
+
+      it "resumes successfully on valid payload" do
+        result = reactor_class.continue(id: execution_id, payload: { status: "ok" })
+
+        expect(result).to be_a(RubyReactor::Success)
+        expect(reactor_class.trace).to include(:process_run)
+        expect(reactor_class.trace).not_to include(:prepare_undo)
+      end
+    end
+
+    context "via reactor.continue (Instance method)" do
+      it "returns invalid_payload result WITHOUT undo" do
+        reactor = reactor_class.find(execution_id)
+
+        result = reactor.continue(payload: { status: "invalid" })
+
+        expect(result).to be_a(RubyReactor::Failure)
+        expect(result.invalid_payload?).to be true
+
+        expect(reactor_class.trace).not_to include(:prepare_undo)
+
+        stored = RubyReactor::Configuration.instance.storage_adapter.retrieve_context(execution_id, reactor_class.name)
+        expect(stored).not_to be_nil
+      end
+    end
+  end
+
+  describe "Explicit Undo" do
+    let(:execution) { reactor_class.run }
+    let(:execution_id) { execution.execution_id }
+
+    before do
+      expect(execution).to be_a(RubyReactor::InterruptResult)
+    end
+
+    it "runs compensations and cancels execution" do
+      expect(reactor_class.trace).to eq([:prepare_run])
+
+      reactor_class.undo(execution_id)
+
+      expect(reactor_class.trace).to include(:prepare_undo)
+
+      stored = RubyReactor::Configuration.instance.storage_adapter.retrieve_context(execution_id, reactor_class.name)
+      expect(stored).to be_nil
+    end
+  end
+
+  describe "Explicit Cancel" do
+    let(:execution) { reactor_class.run }
+    let(:execution_id) { execution.execution_id }
+
+    it "deletes execution WITHOUT compensation" do
+      reactor_class.cancel(id: execution_id, reason: "Manual cancel")
+
+      stored = RubyReactor::Configuration.instance.storage_adapter.retrieve_context(execution_id, reactor_class.name)
+      expect(stored).to be_nil
+
+      expect(reactor_class.trace).not_to include(:prepare_undo)
+    end
+
+    context "Explicit Step Validation" do
+      it "resumes successfully when correct step_name is provided" do
+        reactor_class = InterruptUndoTestReactor
+        execution = reactor_class.run(user_id: "step_check_valid")
+        execution_id = execution.execution_id
+
+        # Resume with correct step name
+        result = reactor_class.continue(
+          id: execution_id,
+          payload: { status: "ok" },
+          step_name: :wait_for_input
+        )
+
+        expect(result).to be_a(RubyReactor::Success)
+      end
+
+      it "raises ValidationError when incorrect step_name is provided" do
+        reactor_class = InterruptUndoTestReactor
+        execution = reactor_class.run(user_id: "step_check_invalid")
+        execution_id = execution.execution_id
+
+        # Resume with incorrect step name
+        expect do
+          reactor_class.continue(
+            id: execution_id,
+            payload: { status: "ok" },
+            step_name: :wrong_step
+          )
+        end.to raise_error(RubyReactor::Error::ValidationError, /expected step 'wait_for_input' but got 'wrong_step'/)
+      end
+    end
+  end
+end

--- a/spec/ruby_reactor/interrupt_undo_spec.rb
+++ b/spec/ruby_reactor/interrupt_undo_spec.rb
@@ -2,44 +2,6 @@
 
 require "spec_helper"
 
-# Define named class globally so persistence via name works
-class InterruptUndoTestReactor < RubyReactor::Reactor
-  def self.trace
-    @trace ||= []
-  end
-
-  step :prepare do
-    run do |_args, context|
-      context.reactor_class.trace << :prepare_run
-      Success("prep")
-    end
-
-    undo do |_result, _args, context|
-      context.reactor_class.trace << :prepare_undo
-      Success()
-    end
-  end
-
-  interrupt :wait_for_input do
-    wait_for :prepare
-
-    validate do
-      required(:status).filled(:string, eql?: "ok")
-    end
-  end
-
-  step :process do
-    argument :payload, result(:wait_for_input)
-
-    run do |args, context|
-      context.reactor_class.trace << :process_run
-      Success(args[:payload])
-    end
-  end
-
-  returns :process
-end
-
 RSpec.describe "Interrupt Compensation and Undo" do
   let(:reactor_class) { InterruptUndoTestReactor }
 

--- a/spec/ruby_reactor/interrupt_undo_spec.rb
+++ b/spec/ruby_reactor/interrupt_undo_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe "Interrupt Compensation and Undo" do
       execution.execution_id
     end
 
-    before do
+    it "starts in an interrupted state" do
       expect(execution).to be_a(RubyReactor::InterruptResult)
       expect(reactor_class.trace).to eq([:prepare_run])
     end
 
-    context "via Reactor.continue (Class method)" do
+    context "when using Reactor.continue (Class method)" do
       it "automatically undos and cancels on invalid payload" do
         # Action & Assertion
         expect do
@@ -46,7 +46,7 @@ RSpec.describe "Interrupt Compensation and Undo" do
       end
     end
 
-    context "via reactor.continue (Instance method)" do
+    context "when using reactor.continue (Instance method)" do
       it "returns invalid_payload result WITHOUT undo" do
         reactor = reactor_class.find(execution_id)
 
@@ -67,11 +67,12 @@ RSpec.describe "Interrupt Compensation and Undo" do
     let(:execution) { reactor_class.run }
     let(:execution_id) { execution.execution_id }
 
-    before do
+    it "starts in an interrupted state" do
       expect(execution).to be_a(RubyReactor::InterruptResult)
     end
 
     it "runs compensations and cancels execution" do
+      execution
       expect(reactor_class.trace).to eq([:prepare_run])
 
       reactor_class.undo(execution_id)
@@ -96,7 +97,7 @@ RSpec.describe "Interrupt Compensation and Undo" do
       expect(reactor_class.trace).not_to include(:prepare_undo)
     end
 
-    context "Explicit Step Validation" do
+    context "with Explicit Step Validation" do
       it "resumes successfully when correct step_name is provided" do
         reactor_class = InterruptUndoTestReactor
         execution = reactor_class.run(user_id: "step_check_valid")

--- a/spec/ruby_reactor/interrupt_undo_spec.rb
+++ b/spec/ruby_reactor/interrupt_undo_spec.rb
@@ -124,7 +124,8 @@ RSpec.describe "Interrupt Compensation and Undo" do
             payload: { status: "ok" },
             step_name: :wrong_step
           )
-        end.to raise_error(RubyReactor::Error::ValidationError, /expected step 'wait_for_input' but got 'wrong_step'/)
+        end.to raise_error(RubyReactor::Error::ValidationError,
+                           /expected step 'wait_for_input' or ready steps .* but got 'wrong_step'/)
       end
     end
   end

--- a/spec/ruby_reactor/multiple_interrupts_spec.rb
+++ b/spec/ruby_reactor/multiple_interrupts_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Multiple Interrupts Reactor" do
+  let(:reactor_class) { MultipleInterruptsReactor }
+
+  before do
+    reactor_class.instance_variable_set(:@trace, [])
+    # Clear Redis
+    RubyReactor::Configuration.instance.storage_adapter.respond_to?(:flushdb) &&
+      RubyReactor::Configuration.instance.storage_adapter.flushdb
+  end
+
+  describe "Phase 1: Concurrent Approvals" do
+    it "pauses for multiple interrupts and resumes when all are satisfied (Sequential)" do
+      # Initial run
+      execution = reactor_class.run
+      execution_id = execution.execution_id
+
+      expect(execution).to be_a(RubyReactor::InterruptResult)
+      expect(reactor_class.trace).to eq([:initiate_transaction])
+
+      # Resume Manager One
+      result_one = reactor_class.continue(
+        id: execution_id,
+        step_name: :manager_one_approval,
+        payload: { status: "approved" }
+      )
+
+      expect(result_one).to be_a(RubyReactor::InterruptResult)
+
+      # Resume Manager Two
+      result_two = reactor_class.continue(
+        id: execution_id,
+        step_name: :manager_two_approval,
+        payload: { status: "approved" }
+      )
+
+      # Should complete Phase 1 and move to Phase 2 (paused at final_approval_1 or 2)
+      expect(result_two).to be_a(RubyReactor::InterruptResult)
+      expect(reactor_class.trace).to include(:complete_transaction, :processing_phase_2)
+    end
+
+    it "pauses for multiple interrupts and resumes in INDIFFERENT order" do
+      # Initial run
+      execution = reactor_class.run
+      execution_id = execution.execution_id
+
+      expect(execution).to be_a(RubyReactor::InterruptResult)
+
+      # Resume Manager TWO first (out of definition order)
+      result_one = reactor_class.continue(
+        id: execution_id,
+        step_name: :manager_two_approval,
+        payload: { status: "approved" }
+      )
+
+      expect(result_one).to be_a(RubyReactor::InterruptResult)
+
+      # Resume Manager ONE second
+      result_two = reactor_class.continue(
+        id: execution_id,
+        step_name: :manager_one_approval,
+        payload: { status: "approved" }
+      )
+
+      # Should complete Phase 1 and move to Phase 2
+      expect(result_two).to be_a(RubyReactor::InterruptResult)
+      expect(reactor_class.trace).to include(:complete_transaction, :processing_phase_2)
+    end
+  end
+
+  describe "Phase 2: Premature Execution Prevention" do
+    it "prevents continuing a future interrupt that is not ready" do
+      # Initial run -> Paused at Phase 1 approvals
+      execution = reactor_class.run
+      execution_id = execution.execution_id
+
+      # Try to approve Phase 2 (final_approval_1) BEFORE Phase 1 is done
+      expect do
+        reactor_class.continue(
+          id: execution_id,
+          step_name: :final_approval_1,
+          payload: { status: "final_ok" }
+        )
+      end.to raise_error(RubyReactor::Error::ValidationError,
+                         /Cannot resume: expected step .* or ready steps .* but got 'final_approval_1'/)
+    end
+  end
+
+  describe "Full Workflow" do
+    it "completes the full multi-phase workflow" do
+      execution = reactor_class.run
+      id = execution.execution_id
+
+      # Phase 1
+      reactor_class.continue(id: id, step_name: :manager_one_approval, payload: { status: "approved" })
+      reactor_class.continue(id: id, step_name: :manager_two_approval, payload: { status: "approved" })
+
+      # Phase 2
+      # Resume Final 1
+      reactor_class.continue(id: id, step_name: :final_approval_1, payload: { status: "final_ok" })
+
+      # Resume Final 2 -> Completion
+      result = reactor_class.continue(id: id, step_name: :final_approval_2, payload: { status: "final_ok" })
+
+      expect(result).to be_a(RubyReactor::Success)
+      expect(result.value).to eq("done")
+      expect(reactor_class.trace).to eq(%i[
+                                          initiate_transaction
+                                          complete_transaction
+                                          processing_phase_2
+                                          final_completion
+                                        ])
+    end
+  end
+end

--- a/spec/support/async_notification_interrupt_reactor.rb
+++ b/spec/support/async_notification_interrupt_reactor.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class AsyncNotificationInterruptReactor < RubyReactor::Reactor
+  def self.trace
+    @trace ||= []
+  end
+
+  step :retrieve_context do
+    run do |_args, context|
+      context.reactor_class.trace << :retrieve_context
+      Success({ user_id: 123 })
+    end
+  end
+
+  step :send_notifications do
+    async true
+    argument :user_id, result(:retrieve_context)
+    run do |args, context|
+      context.reactor_class.trace << :send_notifications
+      # Simulate sending notifications
+      # args[:user_id] is the value directly because retrieve_context returns { user_id: 123 }
+      # Wait, retrieve_context returns Success({ user_id: 123 }).
+      # result(:retrieve_context) resolves to { user_id: 123 }.
+      # argument :user_id, result(:retrieve_context) means args[:user_id] = { user_id: 123 }
+      # We probably want a transform or access the value properly.
+
+      # Let's fix the argument source to grab the specific key or fix the interpolation.
+      # Ideally: argument :user_id, result(:retrieve_context), transform: ->(res) { res[:user_id] }
+
+      Success("notifications_sent_to_#{args[:user_id][:user_id]}")
+    end
+  end
+
+  interrupt :manager_approval do
+    wait_for :send_notifications
+
+    validate do
+      required(:status).filled(:string, eql?: "approved")
+    end
+  end
+
+  step :process_approval do
+    async true
+    argument :notification_status, result(:send_notifications)
+    argument :approval_payload, result(:manager_approval)
+
+    run do |args, context|
+      context.reactor_class.trace << :process_approval
+      Success("processed_#{args[:approval_payload][:status]}_after_#{args[:notification_status]}")
+    end
+  end
+
+  returns :process_approval
+end

--- a/spec/support/interrupt_undo_test_reactor.rb
+++ b/spec/support/interrupt_undo_test_reactor.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Define named class globally so persistence via name works
+class InterruptUndoTestReactor < RubyReactor::Reactor
+  def self.trace
+    @trace ||= []
+  end
+
+  step :prepare do
+    run do |_args, context|
+      context.reactor_class.trace << :prepare_run
+      Success("prep")
+    end
+
+    undo do |_result, _args, context|
+      context.reactor_class.trace << :prepare_undo
+      Success()
+    end
+  end
+
+  interrupt :wait_for_input do
+    wait_for :prepare
+
+    validate do
+      required(:status).filled(:string, eql?: "ok")
+    end
+  end
+
+  step :process do
+    argument :payload, result(:wait_for_input)
+
+    run do |args, context|
+      context.reactor_class.trace << :process_run
+      Success(args[:payload])
+    end
+  end
+
+  returns :process
+end

--- a/spec/support/multiple_interrupts_reactor.rb
+++ b/spec/support/multiple_interrupts_reactor.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class MultipleInterruptsReactor < RubyReactor::Reactor
+  def self.trace
+    @trace ||= []
+  end
+
+  step :initiate_transaction do
+    run do |_args, context|
+      context.reactor_class.trace << :initiate_transaction
+      Success({ amount: 100 })
+    end
+  end
+
+  interrupt :manager_one_approval do
+    wait_for :initiate_transaction
+
+    validate do
+      required(:status).filled(:string, eql?: "approved")
+    end
+  end
+
+  interrupt :manager_two_approval do
+    wait_for :initiate_transaction
+
+    validate do
+      required(:status).filled(:string, eql?: "approved")
+    end
+  end
+
+  step :complete_transaction do
+    argument :approval_one, result(:manager_one_approval)
+    argument :approval_two, result(:manager_two_approval)
+
+    run do |args, context|
+      context.reactor_class.trace << :complete_transaction
+      Success({
+                status: "completed",
+                approvals: [args[:approval_one], args[:approval_two]]
+              })
+    end
+  end
+
+  step :processing_phase_2 do
+    wait_for :complete_transaction
+    run do |_args, context|
+      context.reactor_class.trace << :processing_phase_2
+      Success()
+    end
+  end
+
+  interrupt :final_approval_1 do
+    wait_for :processing_phase_2
+    validate do
+      required(:status).filled(:string, eql?: "final_ok")
+    end
+  end
+
+  interrupt :final_approval_2 do
+    wait_for :processing_phase_2
+    validate do
+      required(:status).filled(:string, eql?: "final_ok")
+    end
+  end
+
+  step :final_completion do
+    argument :final_1, result(:final_approval_1)
+    argument :final_2, result(:final_approval_2)
+
+    run do |_args, context|
+      context.reactor_class.trace << :final_completion
+      Success("done")
+    end
+  end
+
+  returns :final_completion
+end

--- a/spec/support/test_interrupt_reactor.rb
+++ b/spec/support/test_interrupt_reactor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TestInterruptReactor < RubyReactor::Reactor
   input :user_id
 

--- a/spec/support/test_interrupt_reactor.rb
+++ b/spec/support/test_interrupt_reactor.rb
@@ -1,0 +1,30 @@
+class TestInterruptReactor < RubyReactor::Reactor
+  input :user_id
+
+  step :prepare do
+    argument :user_id, input(:user_id)
+    run do |args|
+      Success("prepared-#{args[:user_id]}")
+    end
+  end
+
+  interrupt :wait_for_approval do
+    wait_for :prepare
+
+    correlation_id do |context|
+      "approval-#{context.result(:prepare)}"
+    end
+
+    validate do
+      required(:status).filled(:string)
+      required(:approver).filled(:string)
+    end
+  end
+
+  step :finalize do
+    argument :approval_data, result(:wait_for_approval)
+    run do |args|
+      Success("finalized-#{args[:approval_data][:status]}-by-#{args[:approval_data][:approver]}")
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a major new feature to RubyReactor: the ability to pause and resume workflow execution using "interrupts." This supports long-running processes that require external input (such as webhooks or human approvals). The PR also updates documentation, expands the DSL, and improves context serialization for cancellations and async execution tracking.

**Key changes include:**

### Interrupts Feature & DSL

* Added the `interrupt` DSL keyword, allowing reactors to pause execution at defined steps and wait for external input before resuming. This includes options for correlation IDs, timeouts, and payload validation. [[1]](diffhunk://#diff-ffd8f6cebe4d69f9b314b773e0630757cd2c9556abd234c0cdc7204c842bb24eR1-R42) [[2]](diffhunk://#diff-747fa5adb0bee819ddeb837a996de0beb4227dbe2b606136755d5bc44e202ed8R1-R20) [[3]](diffhunk://#diff-15db39bd60b0287f705d3342ecafdf61d547b468b866dd95df1b5ca85add043eR21-R23) [[4]](diffhunk://#diff-15db39bd60b0287f705d3342ecafdf61d547b468b866dd95df1b5ca85add043eR112-R120)
* Enhanced the executor to handle interrupts: context is persisted, and correlation ID mappings are stored for later resumption. [[1]](diffhunk://#diff-e083e48b76ce6233e7f70b55808f179421c39810657361eec78ef55ff4cde832R47-R74) [[2]](diffhunk://#diff-e083e48b76ce6233e7f70b55808f179421c39810657361eec78ef55ff4cde832R87-R95) [[3]](diffhunk://#diff-e083e48b76ce6233e7f70b55808f179421c39810657361eec78ef55ff4cde832L96-R117) [[4]](diffhunk://#diff-e083e48b76ce6233e7f70b55808f179421c39810657361eec78ef55ff4cde832R143-R156)

### Documentation Updates

* Added a comprehensive `interrupts.md` guide explaining usage, options, runtime behavior, resumption, cancellation, and common use cases.
* Updated `README.md` to document the new interrupts feature, provide usage examples, link to the new guide, and mark interrupts as a completed roadmap item. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R202-R237) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R580-R582) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L551-R603)

### Context & Async Improvements

* Extended the `Context` object to track cancellation state and reason, and improved serialization/deserialization to persist these fields. Also added convenient `input` and `result` aliases. [[1]](diffhunk://#diff-0696c8ae0f4e6ffbd959f758badd0645aefdd4fafe4fb9ad101a578c666614b4L7-R8) [[2]](diffhunk://#diff-0696c8ae0f4e6ffbd959f758badd0645aefdd4fafe4fb9ad101a578c666614b4R27-R28) [[3]](diffhunk://#diff-0696c8ae0f4e6ffbd959f758badd0645aefdd4fafe4fb9ad101a578c666614b4R43) [[4]](diffhunk://#diff-0696c8ae0f4e6ffbd959f758badd0645aefdd4fafe4fb9ad101a578c666614b4R55) [[5]](diffhunk://#diff-0696c8ae0f4e6ffbd959f758badd0645aefdd4fafe4fb9ad101a578c666614b4L98-R105) [[6]](diffhunk://#diff-0696c8ae0f4e6ffbd959f758badd0645aefdd4fafe4fb9ad101a578c666614b4L119-R127)
* The async router now includes the execution ID in `AsyncResult`, making it easier to track async executions. [[1]](diffhunk://#diff-a5bcb451cc0f3ca6a05c5520fe460d7b5e172ae895d058e673956d517bab9cd1L123-R128) [[2]](diffhunk://#diff-934003cfccc9fd67380c2c19835688e35f45dd4ec9e3d481574f056e85060ad1L7-R16)

### Rubocop & Code Quality

* Updated Rubocop configuration to relax method and class length limits and add new rules for variable numbers and module length, supporting the expanded codebase. [[1]](diffhunk://#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cL30-R36) [[2]](diffhunk://#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cR99-R105)

---

**References:**  
[[1]](diffhunk://#diff-ffd8f6cebe4d69f9b314b773e0630757cd2c9556abd234c0cdc7204c842bb24eR1-R42) [[2]](diffhunk://#diff-747fa5adb0bee819ddeb837a996de0beb4227dbe2b606136755d5bc44e202ed8R1-R20) [[3]](diffhunk://#diff-15db39bd60b0287f705d3342ecafdf61d547b468b866dd95df1b5ca85add043eR21-R23) [[4]](diffhunk://#diff-15db39bd60b0287f705d3342ecafdf61d547b468b866dd95df1b5ca85add043eR112-R120) [[5]](diffhunk://#diff-e083e48b76ce6233e7f70b55808f179421c39810657361eec78ef55ff4cde832R47-R74) [[6]](diffhunk://#diff-e083e48b76ce6233e7f70b55808f179421c39810657361eec78ef55ff4cde832R87-R95) [[7]](diffhunk://#diff-e083e48b76ce6233e7f70b55808f179421c39810657361eec78ef55ff4cde832L96-R117) [[8]](diffhunk://#diff-e083e48b76ce6233e7f70b55808f179421c39810657361eec78ef55ff4cde832R143-R156) [[9]](diffhunk://#diff-339ea45af741125d58639b04b434b475478ea86b8ffdb6cf0fb46b2b382c682eR1-R155) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R202-R237) [[12]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R580-R582) [[13]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L551-R603) [[14]](diffhunk://#diff-0696c8ae0f4e6ffbd959f758badd0645aefdd4fafe4fb9ad101a578c666614b4L7-R8) [[15]](diffhunk://#diff-0696c8ae0f4e6ffbd959f758badd0645aefdd4fafe4fb9ad101a578c666614b4R27-R28) [[16]](diffhunk://#diff-0696c8ae0f4e6ffbd959f758badd0645aefdd4fafe4fb9ad101a578c666614b4R43) [[17]](diffhunk://#diff-0696c8ae0f4e6ffbd959f758badd0645aefdd4fafe4fb9ad101a578c666614b4R55) [[18]](diffhunk://#diff-0696c8ae0f4e6ffbd959f758badd0645aefdd4fafe4fb9ad101a578c666614b4L98-R105) [[19]](diffhunk://#diff-0696c8ae0f4e6ffbd959f758badd0645aefdd4fafe4fb9ad101a578c666614b4L119-R127) [[20]](diffhunk://#diff-a5bcb451cc0f3ca6a05c5520fe460d7b5e172ae895d058e673956d517bab9cd1L123-R128) [[21]](diffhunk://#diff-934003cfccc9fd67380c2c19835688e35f45dd4ec9e3d481574f056e85060ad1L7-R16) [[22]](diffhunk://#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cL30-R36) [[23]](diffhunk://#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cR99-R105)