### PR TITLE
feat: enhance deserialization error handling in Sidekiq worker

### DIFF
--- a/lib/ruby_reactor/context_serializer.rb
+++ b/lib/ruby_reactor/context_serializer.rb
@@ -145,7 +145,7 @@ module RubyReactor
             when "Regexp"
               Regexp.new(value["source"], value["options"])
             when "GlobalID"
-              GlobalID::Locator.locate(value["gid"])
+              locate_global_id(value["gid"])
             when "Template::Element"
               RubyReactor::Template::Element.new(value["map_name"], value["path"])
             when "Template::Input"
@@ -197,6 +197,15 @@ module RubyReactor
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength
 
       private
+
+      def locate_global_id(gid)
+        unless defined?(GlobalID::Locator)
+          raise RubyReactor::Error::DeserializationError,
+                "globalid gem is required to deserialize GlobalID values (gid: #{gid})"
+        end
+
+        GlobalID::Locator.locate(gid)
+      end
 
       def validate_size(data)
         size = data.bytesize

--- a/lib/ruby_reactor/map/result_enumerator.rb
+++ b/lib/ruby_reactor/map/result_enumerator.rb
@@ -60,6 +60,7 @@ module RubyReactor
       end
 
       def [](index)
+        index += count if index.negative?
         return nil if index.negative? || index >= count
 
         results = @storage.retrieve_map_results_batch(
@@ -80,7 +81,7 @@ module RubyReactor
       end
 
       def last
-        self[count - 1]
+        self[-1]
       end
 
       def successes

--- a/lib/ruby_reactor/map/result_enumerator.rb
+++ b/lib/ruby_reactor/map/result_enumerator.rb
@@ -80,7 +80,7 @@ module RubyReactor
       end
 
       def last
-        self[-1]
+        self[count - 1]
       end
 
       def successes

--- a/lib/ruby_reactor/map/result_enumerator.rb
+++ b/lib/ruby_reactor/map/result_enumerator.rb
@@ -80,15 +80,15 @@ module RubyReactor
       end
 
       def last
-        self[count - 1]
+        self[-1]
       end
 
       def successes
-        lazy.select { |result| result.is_a?(RubyReactor::Success) }.map(&:value)
+        lazy.grep(RubyReactor::Success).map(&:value)
       end
 
       def failures
-        lazy.select { |result| result.is_a?(RubyReactor::Failure) }.map(&:error)
+        lazy.grep(RubyReactor::Failure).map(&:error)
       end
 
       private

--- a/lib/ruby_reactor/rate_limit.rb
+++ b/lib/ruby_reactor/rate_limit.rb
@@ -15,7 +15,7 @@ module RubyReactor
     class ExceededError < StandardError
       attr_reader :retry_after_seconds, :key_base, :limit, :period_seconds, :period_name
 
-      def initialize(message, retry_after_seconds:, key_base:, limit:, period_seconds:, period_name:)
+      def initialize(message, retry_after_seconds:, key_base:, limit:, period_seconds:, period_name:) # rubocop:disable Metrics/ParameterLists
         super(message)
         @retry_after_seconds = retry_after_seconds
         @key_base = key_base

--- a/lib/ruby_reactor/rate_limit.rb
+++ b/lib/ruby_reactor/rate_limit.rb
@@ -42,7 +42,7 @@ module RubyReactor
       @limits.each do |spec|
         argv << spec[:period_seconds]
         argv << spec[:limit]
-        argv << spec[:period_seconds] * 2 # TTL: generous, auto-cleans stale buckets
+        argv << (spec[:period_seconds] * 2) # TTL: generous, auto-cleans stale buckets
       end
 
       allowed, retry_after, failed_index = adapter.rate_limit_check_and_increment(keys, argv)

--- a/lib/ruby_reactor/sidekiq_workers/worker.rb
+++ b/lib/ruby_reactor/sidekiq_workers/worker.rb
@@ -18,7 +18,16 @@ module RubyReactor
       end
 
       def perform(serialized_context, reactor_class_name = nil, snooze_count = 0)
-        context = ContextSerializer.deserialize(serialized_context)
+        begin
+          context = ContextSerializer.deserialize(serialized_context)
+        rescue RubyReactor::Error::DeserializationError,
+               RubyReactor::Error::SchemaVersionError => e
+          # Permanent failures — retrying the same blob will keep failing.
+          # Mark the context as failed (best-effort) and return so Sidekiq
+          # does not burn its retry budget.
+          handle_deserialization_failure(serialized_context, reactor_class_name, e)
+          return
+        end
 
         # If reactor_class_name is provided, use it to get the reactor class
         # This handles cases where the class can't be found via const_get
@@ -109,6 +118,54 @@ module RubyReactor
       def log_infrastructure_failure(msg, exception)
         RubyReactor.configuration.logger.error("RubyReactor infrastructure failure: #{exception.message}")
         RubyReactor.configuration.logger.error("Job details: #{msg.inspect}")
+      end
+
+      def handle_deserialization_failure(serialized_context, reactor_class_name, error)
+        metadata = extract_failure_metadata(serialized_context)
+        context_id = metadata[:context_id]
+        resolved_reactor_class_name = reactor_class_name || metadata[:reactor_class_name]
+
+        RubyReactor.configuration.logger.error(
+          "RubyReactor deserialization failure for context " \
+          "#{context_id || "unknown"}: #{error.class.name}: #{error.message}"
+        )
+
+        return unless context_id && resolved_reactor_class_name
+
+        payload = build_failed_context_payload(context_id, resolved_reactor_class_name, error)
+        RubyReactor.configuration.storage_adapter.store_context(
+          context_id,
+          payload,
+          resolved_reactor_class_name
+        )
+      rescue StandardError => e
+        # Don't let a persistence failure mask the original deserialization error.
+        RubyReactor.configuration.logger.error(
+          "RubyReactor failed to persist deserialization failure: #{e.class.name}: #{e.message}"
+        )
+      end
+
+      def extract_failure_metadata(serialized_context)
+        data = JSON.parse(serialized_context)
+        {
+          context_id: data["context_id"],
+          reactor_class_name: data["reactor_class"]
+        }
+      rescue StandardError
+        {}
+      end
+
+      def build_failed_context_payload(context_id, reactor_class_name, error)
+        JSON.generate(
+          "schema_version" => ContextSerializer::SCHEMA_VERSION,
+          "context_id" => context_id,
+          "reactor_class" => reactor_class_name,
+          "status" => "failed",
+          "failure_reason" => {
+            "message" => error.message,
+            "exception_class" => error.class.name
+          }
+        )
       end
     end
   end

--- a/spec/async_retry_dsl_spec.rb
+++ b/spec/async_retry_dsl_spec.rb
@@ -2,10 +2,7 @@
 
 require "spec_helper"
 
-# rubocop:disable RSpec/DescribeClass
 RSpec.describe "RubyReactor Async and Retry DSL" do
-  # rubocop:enable RSpec/DescribeClass
-
   describe "Reactor DSL extensions" do
     it "supports async class method" do
       reactor_class = Class.new(RubyReactor::Reactor) do

--- a/spec/async_retry_integration_spec.rb
+++ b/spec/async_retry_integration_spec.rb
@@ -2,9 +2,7 @@
 
 require "spec_helper"
 require "sidekiq/testing"
-# rubocop:disable RSpec/DescribeClass
 RSpec.describe "RubyReactor Async and Retry Integration" do
-  # rubocop:enable RSpec/DescribeClass
   before do
     Sidekiq::Testing.fake!
     Sidekiq::Worker.clear_all

--- a/spec/examples/locking_reactors.rb
+++ b/spec/examples/locking_reactors.rb
@@ -4,7 +4,7 @@ class SimpleLockReactor < RubyReactor::Reactor
   with_lock(ttl: 10) { |inputs| "user_#{inputs[:user_id]}" }
 
   step :process do
-    run do |inputs|
+    run do |_inputs|
       # Simulating work
       RubyReactor.Success(processed: true)
     end
@@ -12,17 +12,17 @@ class SimpleLockReactor < RubyReactor::Reactor
 end
 
 class NestedChildReactor < RubyReactor::Reactor
-  with_lock(ttl: 10) { |inputs| "shared_resource" }
+  with_lock(ttl: 10) { |_inputs| "shared_resource" }
 
   step :child do
-    run do |inputs|
+    run do |_inputs|
       RubyReactor.Success(child_done: true)
     end
   end
 end
 
 class NestedLockReactor < RubyReactor::Reactor
-  with_lock(ttl: 10) { |inputs| "shared_resource" }
+  with_lock(ttl: 10) { |_inputs| "shared_resource" }
 
   compose :parent, NestedChildReactor do
     # Compose automatically links contexts and uses same root_context
@@ -30,10 +30,10 @@ class NestedLockReactor < RubyReactor::Reactor
 end
 
 class SemaphoreReactor < RubyReactor::Reactor
-  with_semaphore(limit: 2, wait: 0) { |inputs| "api_limit" }
+  with_semaphore(limit: 2, wait: 0) { |_inputs| "api_limit" }
 
   step :call_api do
-    run do |inputs|
+    run do |_inputs|
       # Simulating API call
       RubyReactor.Success(api_called: true)
     end

--- a/spec/ruby_reactor/execution_trace_verification_spec.rb
+++ b/spec/ruby_reactor/execution_trace_verification_spec.rb
@@ -2,9 +2,7 @@
 
 require "spec_helper"
 
-# rubocop:disable RSpec/DescribeClass
 RSpec.describe "Execution Trace Verification", type: :integration do
-  # rubocop:enable RSpec/DescribeClass
   let(:captured_output) { StringIO.new }
 
   # rubocop:disable RSpec/ExpectOutput

--- a/spec/ruby_reactor/integration/locking_spec.rb
+++ b/spec/ruby_reactor/integration/locking_spec.rb
@@ -91,8 +91,7 @@ RSpec.describe "Locking Integration" do
       RubyReactor.configuration.lock_snooze_jitter = 0
 
       # Stub SidekiqWorker to capture rescheduling (snooze counter starts at 1)
-      expect(RubyReactor::SidekiqWorkers::Worker).to receive(:perform_in)
-        .with(5.0, instance_of(String), "SimpleLockReactor", 1)
+      allow(RubyReactor::SidekiqWorkers::Worker).to receive(:perform_in)
 
       # Call the worker's perform method with a serialized context
       context = RubyReactor::Context.new({ user_id: 1 }, SimpleLockReactor)
@@ -100,6 +99,9 @@ RSpec.describe "Locking Integration" do
 
       worker = RubyReactor::SidekiqWorkers::Worker.new
       worker.perform(serialized_context, "SimpleLockReactor")
+
+      expect(RubyReactor::SidekiqWorkers::Worker).to have_received(:perform_in)
+        .with(5.0, instance_of(String), "SimpleLockReactor", 1)
     end
   end
 

--- a/spec/ruby_reactor/sidekiq_workers/worker_spec.rb
+++ b/spec/ruby_reactor/sidekiq_workers/worker_spec.rb
@@ -5,8 +5,17 @@ require "sidekiq/testing"
 require "ruby_reactor/sidekiq_workers/worker"
 
 RSpec.describe RubyReactor::SidekiqWorkers::Worker do
-  let(:context) { instance_double(RubyReactor::Context, context_id: "test-execution-id", reactor_class: reactor_class, inline_async_execution: true) }
-  let(:reactor_class) { double("ReactorClass", name: "TestReactor") }
+  subject(:worker) { described_class.new }
+
+  let(:reactor_class) { Class.new { def self.name = "TestReactor" } }
+  let(:context) do
+    instance_double(
+      RubyReactor::Context,
+      context_id: "test-execution-id",
+      reactor_class: reactor_class,
+      inline_async_execution: true
+    )
+  end
   let(:executor) { instance_double(RubyReactor::Executor) }
   let(:serialized_context) { "{}" }
 
@@ -23,25 +32,25 @@ RSpec.describe RubyReactor::SidekiqWorkers::Worker do
 
   describe "#perform" do
     it "executes the reactor" do
-      expect(executor).to receive(:resume_execution)
-      subject.perform(serialized_context)
+      allow(executor).to receive(:resume_execution)
+      worker.perform(serialized_context)
+      expect(executor).to have_received(:resume_execution)
     end
 
     context "when lock acquisition fails" do
       before do
         allow(executor).to receive(:resume_execution).and_raise(RubyReactor::Lock::AcquisitionError)
+        allow(described_class).to receive(:perform_in)
       end
 
       it "reschedules the job with the snooze counter incremented" do
-        expect(described_class).to receive(:perform_in).with(5.0, serialized_context, nil, 1)
-
-        subject.perform(serialized_context)
+        worker.perform(serialized_context)
+        expect(described_class).to have_received(:perform_in).with(5.0, serialized_context, nil, 1)
       end
 
       it "carries the snooze counter forward across reschedules" do
-        expect(described_class).to receive(:perform_in).with(5.0, serialized_context, nil, 4)
-
-        subject.perform(serialized_context, nil, 3)
+        worker.perform(serialized_context, nil, 3)
+        expect(described_class).to have_received(:perform_in).with(5.0, serialized_context, nil, 4)
       end
     end
 
@@ -49,12 +58,12 @@ RSpec.describe RubyReactor::SidekiqWorkers::Worker do
       before do
         allow(executor).to receive(:resume_execution)
           .and_raise(RubyReactor::Semaphore::AcquisitionError)
+        allow(described_class).to receive(:perform_in)
       end
 
       it "reschedules the job" do
-        expect(described_class).to receive(:perform_in).with(5.0, serialized_context, nil, 1)
-
-        subject.perform(serialized_context)
+        worker.perform(serialized_context)
+        expect(described_class).to have_received(:perform_in).with(5.0, serialized_context, nil, 1)
       end
     end
 
@@ -72,12 +81,12 @@ RSpec.describe RubyReactor::SidekiqWorkers::Worker do
 
       before do
         allow(executor).to receive(:resume_execution).and_raise(error)
+        allow(described_class).to receive(:perform_in)
       end
 
       it "uses the error's retry_after_seconds as the snooze delay" do
-        expect(described_class).to receive(:perform_in).with(2.0, serialized_context, nil, 1)
-
-        subject.perform(serialized_context)
+        worker.perform(serialized_context)
+        expect(described_class).to have_received(:perform_in).with(2.0, serialized_context, nil, 1)
       end
 
       it "floors very short retry_after at 0.1s" do
@@ -91,8 +100,8 @@ RSpec.describe RubyReactor::SidekiqWorkers::Worker do
         )
         allow(executor).to receive(:resume_execution).and_raise(tiny)
 
-        expect(described_class).to receive(:perform_in).with(0.1, serialized_context, nil, 1)
-        subject.perform(serialized_context)
+        worker.perform(serialized_context)
+        expect(described_class).to have_received(:perform_in).with(0.1, serialized_context, nil, 1)
       end
     end
 
@@ -109,27 +118,29 @@ RSpec.describe RubyReactor::SidekiqWorkers::Worker do
         allow(RubyReactor.configuration).to receive(:storage_adapter).and_return(adapter)
         allow(adapter).to receive(:store_context)
         allow(RubyReactor.configuration.logger).to receive(:warn)
+        allow(described_class).to receive(:perform_in)
       end
 
       it "does not reschedule" do
-        expect(described_class).not_to receive(:perform_in)
-        subject.perform(serialized_context, nil, 3)
+        worker.perform(serialized_context, nil, 3)
+        expect(described_class).not_to have_received(:perform_in)
       end
 
       it "marks the context as failed and persists it" do
-        expect(context).to receive(:status=).with(:failed)
-        expect(context).to receive(:failure_reason=) do |reason|
-          expect(reason).to include(
+        worker.perform(serialized_context, nil, 3)
+
+        expect(context).to have_received(:status=).with(:failed)
+        expect(context).to have_received(:failure_reason=).with(
+          hash_including(
             exception_class: "RubyReactor::Lock::AcquisitionError",
             snooze_attempts: 3
           )
-        end
-        expect(adapter).to receive(:store_context).with("test-execution-id", "{serialized}", "TestReactor")
-
-        subject.perform(serialized_context, nil, 3)
+        )
+        expect(adapter).to have_received(:store_context).with("test-execution-id", "{serialized}", "TestReactor")
       end
     end
 
+    # rubocop:disable RSpec/MultipleMemoizedHelpers
     context "when deserialization fails" do
       let(:adapter) { instance_double(RubyReactor::Storage::RedisAdapter) }
       let(:error) { RubyReactor::Error::DeserializationError.new("globalid gem missing") }
@@ -149,23 +160,24 @@ RSpec.describe RubyReactor::SidekiqWorkers::Worker do
       end
 
       it "does not raise and returns nil" do
-        expect { subject.perform(raw_blob) }.not_to raise_error
-        expect(subject.perform(raw_blob)).to be_nil
+        expect(worker.perform(raw_blob)).to be_nil
       end
 
       it "does not call the executor" do
-        expect(RubyReactor::Executor).not_to receive(:new)
-        subject.perform(raw_blob)
+        worker.perform(raw_blob)
+        expect(RubyReactor::Executor).not_to have_received(:new)
       end
 
       it "logs the failure" do
-        expect(RubyReactor.configuration.logger).to receive(:error)
+        worker.perform(raw_blob)
+        expect(RubyReactor.configuration.logger).to have_received(:error)
           .with(a_string_including("ctx-broken", "DeserializationError", "globalid gem missing"))
-        subject.perform(raw_blob)
       end
 
       it "persists a failed-status context payload" do
-        expect(adapter).to receive(:store_context) do |context_id, payload, reactor_class_name|
+        worker.perform(raw_blob)
+
+        expect(adapter).to have_received(:store_context) do |context_id, payload, reactor_class_name|
           expect(context_id).to eq("ctx-broken")
           expect(reactor_class_name).to eq("BrokenReactor")
           parsed = JSON.parse(payload)
@@ -173,46 +185,46 @@ RSpec.describe RubyReactor::SidekiqWorkers::Worker do
           expect(parsed["failure_reason"]["exception_class"]).to eq("RubyReactor::Error::DeserializationError")
           expect(parsed["failure_reason"]["message"]).to include("globalid gem missing")
         end
-
-        subject.perform(raw_blob)
       end
 
       it "prefers the reactor_class_name argument over the one embedded in the blob" do
-        expect(adapter).to receive(:store_context).with("ctx-broken", anything, "OverrideReactor")
-        subject.perform(raw_blob, "OverrideReactor")
+        worker.perform(raw_blob, "OverrideReactor")
+        expect(adapter).to have_received(:store_context).with("ctx-broken", anything, "OverrideReactor")
       end
 
       it "skips persistence when context_id cannot be extracted" do
-        expect(adapter).not_to receive(:store_context)
-        subject.perform("not-json-at-all")
+        worker.perform("not-json-at-all")
+        expect(adapter).not_to have_received(:store_context)
       end
 
       it "also catches SchemaVersionError" do
         allow(RubyReactor::ContextSerializer).to receive(:deserialize)
           .and_raise(RubyReactor::Error::SchemaVersionError.new("0.9"))
-        expect { subject.perform(raw_blob) }.not_to raise_error
+        expect { worker.perform(raw_blob) }.not_to raise_error
       end
 
       it "swallows storage failures so the original error is not masked" do
         allow(adapter).to receive(:store_context).and_raise(StandardError, "redis down")
-        expect(RubyReactor.configuration.logger).to receive(:error)
+        expect { worker.perform(raw_blob) }.not_to raise_error
+        expect(RubyReactor.configuration.logger).to have_received(:error)
           .with(a_string_including("failed to persist"))
-        expect { subject.perform(raw_blob) }.not_to raise_error
       end
     end
+
+    # rubocop:enable RSpec/MultipleMemoizedHelpers
 
     context "with jitter configured" do
       before do
         RubyReactor.configuration.lock_snooze_jitter = 5
         allow(executor).to receive(:resume_execution).and_raise(RubyReactor::Lock::AcquisitionError)
+        allow(described_class).to receive(:perform_in)
       end
 
       it "schedules within the [base, base + jitter] window" do
-        allow(described_class).to receive(:perform_in) do |delay, *_rest|
+        worker.perform(serialized_context)
+        expect(described_class).to have_received(:perform_in) do |delay, *_rest|
           expect(delay).to be_between(5.0, 10.0)
         end
-
-        subject.perform(serialized_context)
       end
     end
   end

--- a/spec/ruby_reactor/sidekiq_workers/worker_spec.rb
+++ b/spec/ruby_reactor/sidekiq_workers/worker_spec.rb
@@ -130,6 +130,77 @@ RSpec.describe RubyReactor::SidekiqWorkers::Worker do
       end
     end
 
+    context "when deserialization fails" do
+      let(:adapter) { instance_double(RubyReactor::Storage::RedisAdapter) }
+      let(:error) { RubyReactor::Error::DeserializationError.new("globalid gem missing") }
+      let(:raw_blob) do
+        JSON.generate(
+          "schema_version" => RubyReactor::ContextSerializer::SCHEMA_VERSION,
+          "context_id" => "ctx-broken",
+          "reactor_class" => "BrokenReactor"
+        )
+      end
+
+      before do
+        allow(RubyReactor::ContextSerializer).to receive(:deserialize).and_raise(error)
+        allow(RubyReactor.configuration).to receive(:storage_adapter).and_return(adapter)
+        allow(adapter).to receive(:store_context)
+        allow(RubyReactor.configuration.logger).to receive(:error)
+      end
+
+      it "does not raise and returns nil" do
+        expect { subject.perform(raw_blob) }.not_to raise_error
+        expect(subject.perform(raw_blob)).to be_nil
+      end
+
+      it "does not call the executor" do
+        expect(RubyReactor::Executor).not_to receive(:new)
+        subject.perform(raw_blob)
+      end
+
+      it "logs the failure" do
+        expect(RubyReactor.configuration.logger).to receive(:error)
+          .with(a_string_including("ctx-broken", "DeserializationError", "globalid gem missing"))
+        subject.perform(raw_blob)
+      end
+
+      it "persists a failed-status context payload" do
+        expect(adapter).to receive(:store_context) do |context_id, payload, reactor_class_name|
+          expect(context_id).to eq("ctx-broken")
+          expect(reactor_class_name).to eq("BrokenReactor")
+          parsed = JSON.parse(payload)
+          expect(parsed["status"]).to eq("failed")
+          expect(parsed["failure_reason"]["exception_class"]).to eq("RubyReactor::Error::DeserializationError")
+          expect(parsed["failure_reason"]["message"]).to include("globalid gem missing")
+        end
+
+        subject.perform(raw_blob)
+      end
+
+      it "prefers the reactor_class_name argument over the one embedded in the blob" do
+        expect(adapter).to receive(:store_context).with("ctx-broken", anything, "OverrideReactor")
+        subject.perform(raw_blob, "OverrideReactor")
+      end
+
+      it "skips persistence when context_id cannot be extracted" do
+        expect(adapter).not_to receive(:store_context)
+        subject.perform("not-json-at-all")
+      end
+
+      it "also catches SchemaVersionError" do
+        allow(RubyReactor::ContextSerializer).to receive(:deserialize)
+          .and_raise(RubyReactor::Error::SchemaVersionError.new("0.9"))
+        expect { subject.perform(raw_blob) }.not_to raise_error
+      end
+
+      it "swallows storage failures so the original error is not masked" do
+        allow(adapter).to receive(:store_context).and_raise(StandardError, "redis down")
+        expect(RubyReactor.configuration.logger).to receive(:error)
+          .with(a_string_including("failed to persist"))
+        expect { subject.perform(raw_blob) }.not_to raise_error
+      end
+    end
+
     context "with jitter configured" do
       before do
         RubyReactor.configuration.lock_snooze_jitter = 5

--- a/spec/ruby_reactor/validations_spec.rb
+++ b/spec/ruby_reactor/validations_spec.rb
@@ -3,7 +3,6 @@
 require "spec_helper"
 require "dry-validation"
 
-# rubocop:disable RSpec/DescribeClass
 RSpec.describe "Dry::Validation Integration" do
   describe "Input Validation" do
     describe "basic input validation with schema blocks" do
@@ -902,4 +901,3 @@ RSpec.describe "Dry::Validation Integration" do
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass

--- a/spec/support/examples/data_pipeline.rb
+++ b/spec/support/examples/data_pipeline.rb
@@ -255,7 +255,7 @@ class UserETLReactor < RubyReactor::Reactor
       # Separate successful and failed transformations
       # In inline execution, all results are values (no Result wrappers)
       # In async execution, we'd need to handle Result objects
-      successful_users = users.select { |u| u.is_a?(Hash) }
+      successful_users = users.grep(Hash)
       failed_users = [] # Would contain failures in async mode
 
       result = {


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the RubyReactor codebase, focusing on error handling during context deserialization, enhancements to enumerator and matcher usage, and various test and code quality improvements. The most significant change is robust handling and persistence of deserialization failures in Sidekiq workers, ensuring that failed jobs are properly logged and marked as failed without exhausting retry budgets.

**Error handling and robustness:**

* The `SidekiqWorkers::Worker` now gracefully handles context deserialization failures (`DeserializationError`, `SchemaVersionError`) by logging the error, marking the context as failed, and persisting the failure status. This prevents Sidekiq from retrying jobs that will always fail due to irrecoverable serialization issues. [[1]](diffhunk://#diff-0bccdbf8653ab8c6983b4f3a54b7d7c2661a4364e1159886a9d33a413ad30ffaR21-R30) [[2]](diffhunk://#diff-0bccdbf8653ab8c6983b4f3a54b7d7c2661a4364e1159886a9d33a413ad30ffaR122-R169)
* Added a helper method `locate_global_id` in `ContextSerializer` to raise a clear error if the `globalid` gem is missing, improving error messaging for GlobalID deserialization. [[1]](diffhunk://#diff-5d217d387264e522c65b221b06254a62aeecd9446e1a27d90e34aa46304f747fL148-R148) [[2]](diffhunk://#diff-5d217d387264e522c65b221b06254a62aeecd9446e1a27d90e34aa46304f747fR201-R209)

**Enumerator and matcher improvements:**

* Enhanced negative indexing support in `ResultEnumerator#[]` and refactored `successes` and `failures` to use `grep` for cleaner, more idiomatic code. [[1]](diffhunk://#diff-b4146b719d3e6630aff7627abab1cce0898442e72ea1d32abf7acc4d66a2affaR63) [[2]](diffhunk://#diff-b4146b719d3e6630aff7627abab1cce0898442e72ea1d32abf7acc4d66a2affaL83-R92)

**Testing and code quality:**

* Expanded and improved test coverage for deserialization failures in `SidekiqWorkers::Worker`, including persistence, logging, and edge cases. [[1]](diffhunk://#diff-6bca7b7e0b8b86aaea8ead296f6b9af1b66aaa36224fc2a315e30b436263a856L8-R18) [[2]](diffhunk://#diff-6bca7b7e0b8b86aaea8ead296f6b9af1b66aaa36224fc2a315e30b436263a856L26-R66) [[3]](diffhunk://#diff-6bca7b7e0b8b86aaea8ead296f6b9af1b66aaa36224fc2a315e30b436263a856R84-R89) [[4]](diffhunk://#diff-6bca7b7e0b8b86aaea8ead296f6b9af1b66aaa36224fc2a315e30b436263a856L94-R104) [[5]](diffhunk://#diff-6bca7b7e0b8b86aaea8ead296f6b9af1b66aaa36224fc2a315e30b436263a856R121-L144)
* Updated locking and semaphore test examples to use unused block arguments, improving code clarity and Rubocop compliance.
* Removed unnecessary Rubocop disables and streamlined test files for clarity. [[1]](diffhunk://#diff-5d28311a7fc38a7f49886bdfd97c8181c5b8276c880f93d7f72ba3d9e0ba5490L5-L8) [[2]](diffhunk://#diff-d99b103cb01f4ec217a4dc38c9e2de010ea9a72ef8ca8d73e104f1bef4bf9883L5-L7) [[3]](diffhunk://#diff-f8620dacae0aa336c96ccab51216dfcd622bdd3ec0f7ada1f228669d900920a5L5-L7) [[4]](diffhunk://#diff-0ee411231a940028dacfef4cbc4acbae380d82e677e24a0ffe85b0aefb9892e0L6) [[5]](diffhunk://#diff-0ee411231a940028dacfef4cbc4acbae380d82e677e24a0ffe85b0aefb9892e0L905)

**Other minor improvements:**

* Minor code style and clarity fixes in rate limiting and data pipeline example code. [[1]](diffhunk://#diff-b60f5b67c0f2310861a3e4a601928238f51b02b5cbb71c9270ea7fb5860beff1L18-R18) [[2]](diffhunk://#diff-b60f5b67c0f2310861a3e4a601928238f51b02b5cbb71c9270ea7fb5860beff1L45-R45) [[3]](diffhunk://#diff-fac55479a44c3d94a9fca5006e70274c9a78ff3cfad48f8ce0d71e1987445fbdL258-R258)
* Improved test expectations for Sidekiq job rescheduling in locking specs.

These changes collectively make the system more robust in production environments, improve code readability, and enhance test reliability.